### PR TITLE
python: proposition: import matplotlib only within plot functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Compiled python modules.
 *.pyc
 
+# Pyenv version
+.python-version
+
 # Persisted models.
 *.pkl
 
@@ -15,3 +18,4 @@ build/
 .ipynb_checkpoints
 
 *.*~
+.DS_Store

--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -16,10 +16,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-from matplotlib import pyplot as plt
-from matplotlib.dates import MonthLocator, num2date
-from matplotlib.ticker import FuncFormatter
-
 import numpy as np
 import pandas as pd
 
@@ -892,6 +888,10 @@ class Prophet(object):
         -------
         A matplotlib figure.
         """
+        from matplotlib import pyplot as plt
+        from matplotlib.dates import MonthLocator, num2date
+        from matplotlib.ticker import FuncFormatter
+
         if ax is None:
             fig = plt.figure(facecolor='w', figsize=(10, 6))
             ax = fig.add_subplot(111)
@@ -935,6 +935,10 @@ class Prophet(object):
         -------
         A matplotlib figure.
         """
+        from matplotlib import pyplot as plt
+        from matplotlib.dates import MonthLocator, num2date
+        from matplotlib.ticker import FuncFormatter
+
         # Identify components to be plotted
         components = [('trend', True),
                       ('holidays', self.holidays is not None),
@@ -977,6 +981,9 @@ class Prophet(object):
         -------
         a list of matplotlib artists
         """
+        from matplotlib import pyplot as plt
+        from matplotlib.dates import MonthLocator, num2date
+        from matplotlib.ticker import FuncFormatter
 
         artists = []
         if not ax:
@@ -1009,6 +1016,10 @@ class Prophet(object):
         -------
         a list of matplotlib artists
         """
+        from matplotlib import pyplot as plt
+        from matplotlib.dates import MonthLocator, num2date
+        from matplotlib.ticker import FuncFormatter
+
         artists = []
         if not ax:
             fig = plt.figure(facecolor='w', figsize=(10, 6))
@@ -1047,6 +1058,10 @@ class Prophet(object):
         -------
         a list of matplotlib artists
         """
+        from matplotlib import pyplot as plt
+        from matplotlib.dates import MonthLocator, num2date
+        from matplotlib.ticker import FuncFormatter
+
         artists = []
         if not ax:
             fig = plt.figure(facecolor='w', figsize=(10, 6))
@@ -1087,6 +1102,10 @@ class Prophet(object):
         -------
         a list of matplotlib artists
         """
+        from matplotlib import pyplot as plt
+        from matplotlib.dates import MonthLocator, num2date
+        from matplotlib.ticker import FuncFormatter
+
         artists = []
         if not ax:
             fig = plt.figure(facecolor='w', figsize=(10, 6))

--- a/python/requirements-plot.txt
+++ b/python/requirements-plot.txt
@@ -1,0 +1,1 @@
+matplotlib>=2.0.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,4 +2,3 @@ Cython>=0.22
 pystan>=2.14
 numpy>=1.10.0
 pandas>=0.18.1
-matplotlib>=2.0.0

--- a/python/setup.py
+++ b/python/setup.py
@@ -110,6 +110,9 @@ setup(
         'pandas>=0.18.1',
         'pystan>=2.14',
     ],
+    extras_require = {
+        'plot': ["matplotlib"],
+    },
     zip_safe=False,
     include_package_data=True,
     cmdclass={

--- a/python/setup.py
+++ b/python/setup.py
@@ -106,7 +106,6 @@ setup(
     setup_requires=[
     ],
     install_requires=[
-        'matplotlib',
         'pandas>=0.18.1',
         'pystan>=2.14',
     ],


### PR DESCRIPTION
python: proposition: import matplotlib only within plot functions

another way of dealing with the issue #179 (see PR #271 for another proposition): we keep only one package in the end and people who don't want to plot won't be bothered by this I suppose  

(still not a pro with the python setup tools by the way)

