### PR TITLE
Add function to draw significant changepoints

### DIFF
--- a/utils
+++ b/utils
@@ -1,0 +1,32 @@
+#' Get layers to overlay significant changepoints on prophet forecast plot.
+#'
+#' @param m Prophet model object.
+#' @param threshold Numeric, changepoints where abs(delta) >= threshold are significant. (Default 0.01)
+#' @param cp_color Character, line color. (Default "red")
+#' @param cp_linetype Character or integer, line type. (Default "dashed")
+#' @param trend Logical, if FALSE, do not draw trend line. (Default TRUE)
+#' @param ... Other arguments passed on to layers.
+#'
+#' @return A list of ggplot2 layer.
+#'
+#' @import ggplot2
+#'
+#' @examples
+#' \dontrun{
+#' plot(m, fcst) + layer_changepoints(m)
+#' }
+#'
+#' @export
+layer_changepoints <- function(m, threshold = 0.01, cp_color = "red",
+                               cp_linetype = "dashed", trend = TRUE, ...) {
+  layers <- list()
+  if (trend) {
+    trend_layer <- geom_line(aes_string("ds", "trend"), color = cp_color, ...)
+    layers <- append(layers, trend_layer)
+  }
+  signif_changepoints <- m$changepoints[abs(m$params$delta) >= threshold]
+  cp_layer <- geom_vline(xintercept = as.integer(signif_changepoints),
+                         color = cp_color, linetype = cp_linetype, ...)
+  layers <- append(layers, cp_layer)
+  layers
+}


### PR DESCRIPTION
As a continuation of the pull request (#270),  I created a function to overlay significant change points on prophet forecast plot.
The `layer_changepoints()` returns ggplot2 layer object, and you can use as follows:

```
plot(m, fcst) + layer_changepoints(m)
```

![](https://user-images.githubusercontent.com/7479163/29239483-a02705a4-7f8a-11e7-90fa-6dfd0df8b2fc.png)

I think the way is more flexible than like `plot_changepoint`.
For example, if the package will have a mechanism to detect outliers, we can create similar function.

```
plot(m, fcst) + layer_outliers(m)
```

![](https://user-images.githubusercontent.com/7479163/29239669-9b109f68-7f8e-11e7-86b6-8347fc26986d.png)


Then we can draw that combination easy.

```
plot(m, fcst) + layer_changepoints(m) + layer_outliers(m)
```

![](https://user-images.githubusercontent.com/7479163/29239542-caa9b942-7f8b-11e7-8941-cc4315121154.png)

The function name is merely my idea.
I checked up the manner of ggplot2 for such cases, but I couldn't find.
Only `autolayer()` is a method for a similar situation.
http://ggplot2.tidyverse.org/reference/autolayer.html
The function can use from next version of ggplot2.

Changepoints where `abs(delta) >= threshold` are significant, and you can change threshold (default `0.01`).
You can specify line color (default `"red"`) and line type (default `"dashed"`).
And you can choose whether to draw the trend line.
