### PR TITLE
Prevent value error when sigma=0 (Issue #334)

### DIFF
--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -1132,7 +1132,8 @@ class Prophet(object):
         seasonal = np.matmul(seasonal_features.as_matrix(), beta) * self.y_scale
 
         sigma = self.params['sigma_obs'][iteration]
-        noise = np.random.normal(0, sigma, df.shape[0]) * self.y_scale
+        noise = np.random.normal(0, sigma, df.shape[0]) * self.y_scale \
+            if sigma != 0 else np.zeros(df.shape[0])
 
         return pd.DataFrame({
             'yhat': trend + seasonal + noise,


### PR DESCRIPTION
Replace the `noise` with zeros in `sample_model` when sigma=0 which normally results in a `ValueError` and prevents forecasting.