### PR TITLE
Add R setting for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
-language: python
-python:
-  - "2.7"
-  - "3.6"
-
-install:
-  - pip install --upgrade pip
-  - pip install -U -r python/requirements.txt
-
-script:
-  - cd python && python setup.py develop test
+matrix:
+  include:
+    - language: python
+      python:
+        - "2.7"
+        - "3.6"
+      
+      install:
+        - pip install --upgrade pip
+        - pip install -U -r python/requirements.txt
+      
+      script:
+        - cd python && python setup.py develop test
+    - language: R
+      sudo: false
+      cache: packages
+      # R for travis: see documentation at https://docs.travis-ci.com/user/languages/r

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ matrix:
     - language: R
       sudo: false
       cache: packages
-      # R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
+      before_install:
+        - cd R

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Prophet: Automatic Forecasting Procedure
 
+[![Build Status](https://travis-ci.org/facebook/prophet.svg?branch=master)](https://travis-ci.org/facebook/prophet)
+
 Prophet is a procedure for forecasting time series data.  It is based on an additive model where non-linear trends are fit with yearly and weekly seasonality, plus holidays. It works best with daily periodicity data with at least one year of historical data. Prophet is robust to missing data, shifts in the trend, and large outliers.
 
 Prophet is [open source software](https://code.facebook.com/projects/) released by Facebook's [Core Data Science team](https://research.fb.com/category/data-science/).  It is available for download on [CRAN](https://cran.r-project.org/package=prophet) and [PyPI](https://pypi.python.org/pypi/fbprophet/).


### PR DESCRIPTION
## Summary
- Add R language setting to `.travis.yml`
    - Python also works well. I checked it [forked repository](https://travis-ci.org/teramonagi/prophet)
- Add a status badge to `README.md`

Could you activate Travis CI for this repository from [here](https://travis-ci.org/facebook/prophet)?
It also enables [python's CI](https://github.com/facebook/prophet/pull/160).