### PR TITLE
[WIP] vectorize linear/logistic growth Stan models

### DIFF
--- a/R/inst/stan/prophet_linear_growth.stan
+++ b/R/inst/stan/prophet_linear_growth.stan
@@ -1,40 +1,35 @@
 data {
-  int T;                                // Sample size
-  int<lower=1> K;                       // Number of seasonal vectors
-  vector[T] t;                            // Day
-  vector[T] y;                            // Time-series
-  int S;                                // Number of changepoints
-  matrix[T, S] A;                   // Split indicators
-  real t_change[S];                 // Index of changepoints
-  matrix[T,K] X;                // season vectors
-  vector[K] sigmas;              // scale on seasonality prior
-  real<lower=0> tau;                  // scale on changepoints prior
+  int T;                          // sample size
+  int<lower=1> K;                 // number of seasonal vectors
+  vector[T] t;                    // day
+  vector[T] y;                    // time-series
+  int S;                          // number of changepoints
+  matrix[T, S] A;                 // split indicators
+  vector[S] t_change;             // index of changepoints
+  matrix[T, K] X;                 // season vectors
+  vector[K] sigmas;               // scale on seasonality prior
+  real<lower=0> tau;              // scale on changepoints prior
 }
-
 parameters {
-  real k;                            // Base growth rate
-  real m;                            // offset
-  vector[S] delta;                       // Rate adjustments
-  real<lower=0> sigma_obs;               // Observation noise (incl. seasonal variation)
-  vector[K] beta;                    // seasonal vector
+  real k;                         // base growth rate
+  real m;                         // offset
+  vector[S] delta;                // rate adjustments
+  real<lower=0> sigma_obs;        // error scale (incl. seasonal variation)
+  vector[K] beta;                 // seasonal vector
 }
-
 transformed parameters {
-  vector[S] gamma;                  // adjusted offsets, for piecewise continuity
-
-  for (i in 1:S) {
-    gamma[i] = -t_change[i] * delta[i];
-  }
+  // adjusted offsets for piecewise continuity
+  vector[S] gamma = -t_change .* delta;
 }
 
 model {
-  //priors
+  // priors
   k ~ normal(0, 5);
   m ~ normal(0, 5);
   delta ~ double_exponential(0, tau);
   sigma_obs ~ normal(0, 0.5);
   beta ~ normal(0, sigmas);
 
-  // Likelihood
+  // likelihood
   y ~ normal((k + A * delta) .* t + (m + A * gamma) + X * beta, sigma_obs);
 }

--- a/R/inst/stan/prophet_logistic_growth.stan
+++ b/R/inst/stan/prophet_logistic_growth.stan
@@ -1,52 +1,44 @@
 data {
-  int T;                                // Sample size
-  int<lower=1> K;                       // Number of seasonal vectors
-  vector[T] t;                            // Day
-  vector[T] cap;                          // Capacities
-  vector[T] y;                            // Time-series
-  int S;                                // Number of changepoints
-  matrix[T, S] A;                   // Split indicators
-  real t_change[S];                 // Index of changepoints
-  matrix[T,K] X;                    // season vectors
-  vector[K] sigmas;               // scale on seasonality prior
-  real<lower=0> tau;                  // scale on changepoints prior
+  int T;                             // sample size
+  int<lower=1> K;                    // number of seasonal vectors
+  vector[T] t;                       // day
+  vector[T] cap;                     // capacities
+  vector[T] y;                       // observed time series
+  int S;                             // number of changepoints
+  matrix[T, S] A;                    // split indicators
+  vector[S] t_change;                // index of changepoints
+  matrix[T, K] X;                    // season vectors
+  vector[K] sigmas;                  // seasonality prior scale
+  real<lower=0> tau;                 // changepoints prior scale
 }
-
 parameters {
-  real k;                            // Base growth rate
-  real m;                            // offset
-  vector[S] delta;                       // Rate adjustments
-  real<lower=0> sigma_obs;               // Observation noise (incl. seasonal variation)
+  real k;                            // base growth rate
+  real m;                            // offset in previous segment
+  vector[S] delta;                   // rate adjustments
+  real<lower=0> sigma_obs;           // error scale (incl. seasonal variation)
   vector[K] beta;                    // seasonal vector
 }
-
 transformed parameters {
-  vector[S] gamma;                  // adjusted offsets, for piecewise continuity
-  vector[S + 1] k_s;                 // actual rate in each segment
-  real m_pr;
+  // rate in each segment
+  vector[S + 1] k_s = append_row(k, k + cumulative_sum(delta));
 
-  // Compute the rate in each segment
-  k_s[1] = k;
-  for (i in 1:S) {
-    k_s[i + 1] = k_s[i] + delta[i];
-  }
-
-  // Piecewise offsets
-  m_pr = m; // The offset in the previous segment
+  // adjusted offsets for piecewise continuity
+  vector[S] gamma;
+  real m_pr = m;
   for (i in 1:S) {
     gamma[i] = (t_change[i] - m_pr) * (1 - k_s[i] / k_s[i + 1]);
     m_pr = m_pr + gamma[i];  // update for the next segment
   }
 }
-
 model {
-  //priors
+  // priors
   k ~ normal(0, 5);
   m ~ normal(0, 5);
   delta ~ double_exponential(0, tau);
-  sigma_obs ~ normal(0, 0.1);
+  sigma_obs ~ normal(0, 10);
   beta ~ normal(0, sigmas);
 
-  // Likelihood
-  y ~ normal(cap ./ (1 + exp(-(k + A * delta) .* (t - (m + A * gamma)))) + X * beta, sigma_obs);
+  // likelihood
+  y ~ normal(cap ./ inv_logit((k + A * delta) .* (t - (m + A * gamma)))
+             + X * beta, sigma_obs);
 }


### PR DESCRIPTION
This is the PR for issue #415 

I updated the Stan models for vectorization, which makes them a bit shorter and should make them a bit faster.

I'd like to update for prior scale if the posteriors aren't all roughly unit scale in expectation.  That can make a big difference in speeding up adaptation.  

I also need to know how to test that I didn't break the models in refactoring.  The log densities shouldn't change (though might not be the same to 16 decimal points due to vagaries of floating point non-associativity).

Code copyright owner:  Columbia University
License:  BSD-3 Clause

Columbia has given us a permanent exemption to release Stan-related code open source in perpetuity.