### PR TITLE
make_future_dataframe with extra regressors (#432)

### DIFF
--- a/R/man/make_future_dataframe.Rd
+++ b/R/man/make_future_dataframe.Rd
@@ -4,7 +4,8 @@
 \alias{make_future_dataframe}
 \title{Make dataframe with future dates for forecasting.}
 \usage{
-make_future_dataframe(m, periods, freq = "day", include_history = TRUE)
+make_future_dataframe(m, periods, freq = "day", include_history = TRUE,
+  include_extra_regressors = TRUE)
 }
 \arguments{
 \item{m}{Prophet model object.}
@@ -15,6 +16,8 @@ make_future_dataframe(m, periods, freq = "day", include_history = TRUE)
 
 \item{include_history}{Boolean to include the historical dates in the data
 frame for predictions.}
+
+\item{include_extra_regressors}{Add extra regressors to dataframe.}
 }
 \value{
 Dataframe that extends forward from the end of m$history for the


### PR DESCRIPTION
I've altered the default behavior of `make_future_dataframe()` to accommodate added regressors, and it outputs a warning if NA values are replaced with 0, which is necessary for `predict()` (more specifically `setup_dataframe()`) to not error.   The adjustment is turned on by default through a parameter to the function.  

The following illustrates the example from (#432) re-run, and the new warning:

```r
library(tidyverse)
library(lubridate)
library(prophet)
data_url <- "https://raw.githubusercontent.com/facebook/prophet/master/examples/example_wp_peyton_manning.csv"
df <- read_csv(data_url, col_types = cols()) %>% 
    mutate(ds=as_datetime(ds), y=log(y))
extra_dates <- as_datetime(seq(ymd('2007-12-01'), 
                               ymd('2016-03-01'), by='day'))
extra <- tibble(ds=extra_dates, whatever=rnorm(length(extra_dates)))
df <- df %>% left_join(extra, by="ds")
m <- prophet(df, fit=FALSE)
m <- add_regressor(m, 'whatever', standardize = FALSE)
m <- fit.prophet(m, df)
##Disabling daily seasonality. Run prophet with daily.seasonality=TRUE to override this.
##Initial log joint probability = -19.4685
##Optimization terminated normally: 
##  Convergence detected: relative gradient magnitude is below tolerance
future <- make_future_dataframe(m, periods = 365)
##Warning message:
##In make_future_dataframe(m, periods = 365) :
##  NAs detected in joined extra regressor 'whatever' and auto-replaced with zeros
forecast <- predict(m, future)
##|============================================================================|100% ~0 s remaining
```