### PR TITLE
make_future_dataframe() with extra regressors (#432)

### DIFF
--- a/R/man/make_future_dataframe.Rd
+++ b/R/man/make_future_dataframe.Rd
@@ -4,7 +4,8 @@
 \alias{make_future_dataframe}
 \title{Make dataframe with future dates for forecasting.}
 \usage{
-make_future_dataframe(m, periods, freq = "day", include_history = TRUE)
+make_future_dataframe(m, periods, freq = "day", include_history = TRUE,
+  include_extra_regressors = TRUE)
 }
 \arguments{
 \item{m}{Prophet model object.}
@@ -15,6 +16,8 @@ make_future_dataframe(m, periods, freq = "day", include_history = TRUE)
 
 \item{include_history}{Boolean to include the historical dates in the data
 frame for predictions.}
+
+\item{include_extra_regressors}{Add extra regressors to dataframe.}
 }
 \value{
 Dataframe that extends forward from the end of m$history for the

--- a/R/tests/testthat/test_prophet.R
+++ b/R/tests/testthat/test_prophet.R
@@ -319,18 +319,83 @@ test_that("fit_with_holidays", {
 })
 
 test_that("make_future_dataframe", {
-  skip_if_not(Sys.getenv('R_ARCH') != '/i386')
-  train.t <- DATA[1:234, ]
-  m <- prophet(train.t)
-  future <- make_future_dataframe(m, periods = 3, freq = 'day',
-                                  include_history = FALSE)
-  correct <- prophet:::set_date(c('2013-04-26', '2013-04-27', '2013-04-28'))
-  expect_equal(future$ds, correct)
+    skip_if_not(Sys.getenv('R_ARCH') != '/i386')
+    train.t <- DATA[1:234, ]
+    m <- prophet(train.t)
+    future <- make_future_dataframe(m, periods = 3, freq = 'day',
+                                    include_history = FALSE)
+    correct <- prophet:::set_date(c('2013-04-26', '2013-04-27', '2013-04-28'))
+    expect_equal(future$ds, correct)
+    
+    future <- make_future_dataframe(m, periods = 3, freq = 'month',
+                                    include_history = FALSE)
+    correct <- prophet:::set_date(c('2013-05-25', '2013-06-25', '2013-07-25'))
+    expect_equal(future$ds, correct)
 
-  future <- make_future_dataframe(m, periods = 3, freq = 'month',
-                                  include_history = FALSE)
-  correct <- prophet:::set_date(c('2013-05-25', '2013-06-25', '2013-07-25'))
-  expect_equal(future$ds, correct)
+    # test with history
+    train.t.days <- as.character(m$history.dates)
+    future <- make_future_dataframe(m, periods = 3, freq = 'day')
+    correct <- prophet:::set_date(c(train.t.days, '2013-04-26', '2013-04-27', '2013-04-28'))
+    expect_equal(future$ds, correct)
+    
+    future <- make_future_dataframe(m, periods = 3, freq = 'month')
+    correct <- prophet:::set_date(c(train.t.days, '2013-05-25', '2013-06-25', '2013-07-25'))
+    expect_equal(future$ds, correct)
+    
+})
+
+test_that("make_future_dataframe_extra_regressor", {
+    skip_if_not(Sys.getenv('R_ARCH') != '/i386')
+    train.t <- dplyr::mutate(DATA[1:234, ], extra=rnorm(234))
+    
+    m <- prophet(train.t, fit=FALSE)
+    m <- add_regressor(m, 'extra')
+    m <- fit.prophet(m, train.t)
+    # first test without the extra column (i.e. repeat basic make_future_dataframe
+    # test after modifying m)
+    future <- make_future_dataframe(m, periods = 3, freq = 'day',
+                                    include_history = FALSE, include_extra_regressors = FALSE)
+    correct <- prophet:::set_date(c('2013-04-26', '2013-04-27', '2013-04-28'))
+    expect_equal(future$ds, correct)
+    
+    future <- make_future_dataframe(m, periods = 3, freq = 'month',
+                                    include_history = FALSE, include_extra_regressors = FALSE)
+    correct <- prophet:::set_date(c('2013-05-25', '2013-06-25', '2013-07-25'))
+    expect_equal(future$ds, correct)
+    # check extra column is made, noting the warning we're expecting
+    expect_warning({
+        future <- make_future_dataframe(m, periods = 3, freq = 'day',
+                                    include_history = FALSE)
+        expect_named(future, c('ds', 'extra'))
+        correct <- prophet:::set_date(c('2013-04-26', '2013-04-27', '2013-04-28'))
+        expect_equal(future$ds, correct)
+        expect_equal(sum(future$extra), 0)
+    })
+    # same as above, just on the monthly frequency
+    expect_warning({
+        future <- make_future_dataframe(m, periods = 3, freq = 'month',
+                                    include_history = FALSE)
+        expect_named(future, c('ds', 'extra'))
+        correct <- prophet:::set_date(c('2013-05-25', '2013-06-25', '2013-07-25'))
+        expect_equal(future$ds, correct)
+        expect_equal(sum(future$extra), 0)
+    })
+    # once again, with history.  This time though the 'extra' column won't be all
+    # zeros.  Make sure it's the same as in m$history
+    train.t.days <- as.character(m$history.dates)
+    expect_warning({
+        future <- make_future_dataframe(m, periods = 3, freq = 'day')
+        expect_named(future, c('ds', 'extra'))
+        correct <- prophet:::set_date(c(train.t.days, '2013-04-26', '2013-04-27', '2013-04-28'))
+        expect_equal(future$ds, correct)
+    })
+    expect_warning({
+        future <- make_future_dataframe(m, periods = 3, freq = 'month')
+        expect_named(future, c('ds', 'extra'))
+        correct <- prophet:::set_date(c(train.t.days, '2013-05-25', '2013-06-25', '2013-07-25'))
+        expect_equal(future$ds, correct)
+    })
+    
 })
 
 test_that("auto_weekly_seasonality", {

--- a/R/tests/testthat/test_prophet.R
+++ b/R/tests/testthat/test_prophet.R
@@ -388,12 +388,14 @@ test_that("make_future_dataframe_extra_regressor", {
         expect_named(future, c('ds', 'extra'))
         correct <- prophet:::set_date(c(train.t.days, '2013-04-26', '2013-04-27', '2013-04-28'))
         expect_equal(future$ds, correct)
+        expect_equal(sum(future$extra), sum(m$history$extra), tolerance=0.001)
     })
     expect_warning({
         future <- make_future_dataframe(m, periods = 3, freq = 'month')
         expect_named(future, c('ds', 'extra'))
         correct <- prophet:::set_date(c(train.t.days, '2013-05-25', '2013-06-25', '2013-07-25'))
         expect_equal(future$ds, correct)
+        expect_equal(sum(future$extra), sum(m$history$extra), tolerance=0.001)
     })
     
 })


### PR DESCRIPTION
_Sorry for the earlier pull request #446 that I opened, then closed after realizing I didn't use the right e-mail address or GPG sign my commit._

I've altered the default behavior of `make_future_dataframe()` to accommodate added regressors, and it outputs a warning if NA values are replaced with 0, which is necessary for `predict()` (more specifically `setup_dataframe()`) to not error.   The adjustment is turned on by default through a parameter to the function.  

Illustrated below is the example from #432 after this commit:

```r
library(tidyverse)
library(lubridate)
library(prophet)
data_url <- "https://raw.githubusercontent.com/facebook/prophet/master/examples/example_wp_peyton_manning.csv"
df <- read_csv(data_url, col_types = cols()) %>% 
    mutate(ds=as_datetime(ds), y=log(y))
extra_dates <- as_datetime(seq(ymd('2007-12-01'), 
                               ymd('2016-03-01'), by='day'))
extra <- tibble(ds=extra_dates, whatever=rnorm(length(extra_dates)))
df <- df %>% left_join(extra, by="ds")
m <- prophet(df, fit=FALSE)
m <- add_regressor(m, 'whatever', standardize = FALSE)
m <- fit.prophet(m, df)
##Disabling daily seasonality. Run prophet with daily.seasonality=TRUE to override this.
##Initial log joint probability = -19.4685
##Optimization terminated normally: 
##  Convergence detected: relative gradient magnitude is below tolerance
future <- make_future_dataframe(m, periods = 365)
##Warning message:
##In make_future_dataframe(m, periods = 365) :
##  NAs detected in joined extra regressor 'whatever' and auto-replaced with zeros
forecast <- predict(m, future)
##|============================================================================|100% ~0 s remaining
```

Prior to committing, I checked that I didn't add errors/warnings/notes with:

```r
devtools::check(pkg="R")
```
and nothing was mentioned.  