### PR TITLE
unaddressed warnings from unit tests

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -32,3 +32,4 @@ LazyData: true
 RoxygenNote: 6.0.1
 VignetteBuilder: knitr
 SystemRequirements: C++11
+Encoding: UTF-8


### PR DESCRIPTION
These are warnings I encountered in testthat unit tests independent of my other PR.  Here was the bottom of my output from `devtools::test()`:

```
test_prophet.R:28: warning: fit_predict_no_changepoints
non-zero return code in optimizing

test_prophet.R:39: warning: fit_predict_changepoint_not_in_history
non-zero return code in optimizing

test_prophet.R:294: warning: holidays
Unequal factor levels: coercing to character

test_prophet.R:294: warning: holidays
binding character and factor vector, coercing into character vector

test_prophet.R:294: warning: holidays
binding character and factor vector, coercing into character vector

test_prophet.R:354: warning: auto_weekly_seasonality
non-zero return code in optimizing
──────────────────────────────────────────────────────────────────

══ Results ═══════════════════════════════════════════════════════
Duration: 70.1 s

OK:       232
Failed:   0
Warnings: 6
Skipped:  0
Warning message:
`encoding` is deprecated; all files now assumed to be UTF-8
```

The bottom warning comes from devtools expecting "Encoding" to be set at the package level in the DESCRIPTION file.  After the two commits:

```
══ Results ═══════════════════════════════════════════════════════
Duration: 68.9 s

OK:       235
Failed:   0
Warnings: 0
Skipped:  0
```