### PR TITLE
Make matplotlib non mandatory

### DIFF
--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -17,9 +17,13 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-from matplotlib import pyplot as plt
-from matplotlib.dates import MonthLocator, num2date
-from matplotlib.ticker import FuncFormatter
+try:
+    from matplotlib import pyplot as plt
+    from matplotlib.dates import MonthLocator, num2date
+    from matplotlib.ticker import FuncFormatter
+except:
+    logger.warning('matplotlib unavailable : continuing')
+
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
Hey guys,

Yesterday, I tried to parallelize the computation of prediction for a thousand time series on Apache Spark using user defined aggregate function that include fbprophet (pandas_udf).

I quickly run in the issue of matplotlib and its dependency that were required but not used. Indeed, it was a pain because while I had the right to load library on Spark executors I did not had the right to install system wide package (Tkinter needed by matplotlib).

So I forked the repo and made the import of matplotlib non blocking on failure (warning when import fail). It worked and computation were lighting fast on Spark for a thousand time series. I believe making the import of matplotlib non blocking on failure is better/useful for productizing fbprophet.
