### PR TITLE
Fixes #489 Install dependencies directly from requirements.txt in pip installation

### DIFF
--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -7,3 +7,5 @@ prune fbprophet/stan_models
 
 # Necessary for tests to run
 include fbprophet/tests/*.csv
+
+include requirements.txt

--- a/python/README.md
+++ b/python/README.md
@@ -38,9 +38,9 @@ Example usage
 
 ::
 
-  >>> from fbprophet import Prophet
-  >>> m = Prophet()
-  >>> m.fit(df)  # df is a pandas.DataFrame with 'y' and 'ds' columns
-  >>> future = m.make_future_dataframe(periods=365)
-  >>> m.predict(future)
+  > from fbprophet import Prophet
+  > m = Prophet()
+  > m.fit(df)  # df is a pandas.DataFrame with 'y' and 'ds' columns
+  > future = m.make_future_dataframe(periods=365)
+  > m.predict(future)
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -14,6 +14,8 @@ from setuptools.command.build_py import build_py
 from setuptools.command.develop import develop
 from setuptools.command.test import test as test_command
 
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
 
 PLATFORM = 'unix'
 if platform.platform().startswith('Win'):
@@ -106,11 +108,7 @@ setup(
     packages=['fbprophet', 'fbprophet.tests'],
     setup_requires=[
     ],
-    install_requires=[
-        'matplotlib',
-        'pandas>=0.18.1',
-        'pystan>=2.14',
-    ],
+    install_requires=requirements,
     zip_safe=False,
     include_package_data=True,
     # For Python 3, Will enforce that tests are run after a build.


### PR DESCRIPTION
Fixes #489 Install dependencies directly from requirements.txt in pip installation

@bletham Please review thanks.