### PR TITLE
Fix to logging

### DIFF
--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -34,7 +34,7 @@ from fbprophet.plot import (
     plot_seasonality,
 )
 
-logging.basicConfig()
+
 logger = logging.getLogger(__name__)
 warnings.filterwarnings("default", category=DeprecationWarning)
 

--- a/python/fbprophet/plot.py
+++ b/python/fbprophet/plot.py
@@ -18,7 +18,6 @@ import pandas as pd
 from fbprophet.diagnostics import performance_metrics
 
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 try:


### PR DESCRIPTION
This addresses issue #556 

The problem occurs because the basicConfig method is called in two of the modules. As noted in the logging docs:

> Note It is strongly advised that you do not add any handlers other than NullHandler to your library’s loggers. This is because the configuration of handlers is the prerogative of the application developer who uses your library. The application developer knows their target audience and what handlers are most appropriate for their application: if you add handlers ‘under the hood’, you might well interfere with their ability to carry out unit tests and deliver logs which suit their requirements.

[https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library](url)

Incidentally, this same mistake was also made in the pystan package, so even when this fix is implemented, the bug will still occur until pystan fixes their version. I have a fork of pystan with the basicConfig call removed at https://github.com/collincburton/pystan if you want to try it with the fix implemented.