### PR TITLE
Explicitly use 64-bit integers in plot functions

### DIFF
--- a/python/fbprophet/plot.py
+++ b/python/fbprophet/plot.py
@@ -461,8 +461,8 @@ def plot_cross_validation_metric(df_cv, metric, rolling_window=0.1, ax=None):
         if np.timedelta64(1, dt) < np.timedelta64(tick_w, 'ns'):
             break
 
-    x_plt = df_none['horizon'].astype('timedelta64[ns]').astype(int) / float(dt_conversions[i])
-    x_plt_h = df_h['horizon'].astype('timedelta64[ns]').astype(int) / float(dt_conversions[i])
+    x_plt = df_none['horizon'].astype('timedelta64[ns]').astype(np.int64) / float(dt_conversions[i])
+    x_plt_h = df_h['horizon'].astype('timedelta64[ns]').astype(np.int64) / float(dt_conversions[i])
 
     ax.plot(x_plt, df_none[metric], '.', alpha=0.5, c='gray')
     ax.plot(x_plt_h, df_h[metric], '-', c='b')


### PR DESCRIPTION
If this is installed on a 32-bit system (rare nowadays, but they still exist) then the conversion to `int` from `timedelta64[ns]` in `plot_cross_validation_metric` will fail. This patch explicitly uses an `np.int64` for this conversion to save some people headaches.

Thanks for making this project available.