### PR TITLE
Fix broken internal links in hamburger menu

### DIFF
--- a/docs/_includes/nav/header_nav.html
+++ b/docs/_includes/nav/header_nav.html
@@ -6,7 +6,11 @@
     <ul>
       {% for item in site.data.nav %}
       <li class="navItem">
-        <a href="{{ item.href }}"{% if item.category == "external" %} target="_blank"{% endif %}>{{ item.title }}</a>
+        {% if item.category == "external" %}
+          <a href="{{ item.href }}"  target="_blank">{{ item.title }}</a>
+        {% else %}
+          <a href="{{ item.href | relative_url }}">{{ item.title }}</a>
+        {% endif %}
       </li>
       {% endfor %}
       {% if site.searchconfig %}


### PR DESCRIPTION
While browsing the docs in mobile I realize that some internal links are broken. For example if you are in [quick-start](https://facebook.github.io/prophet/docs/quick_start.html) and click on 'Docs' (in the hamburger menu) you'll get redirected to https://facebook.github.io/prophet/docs/docs/ and get a 404.

Fixed using the `relative_url` jekyll filter for internal links.

