### PR TITLE
Fix table header case in quick_start.md

### DIFF
--- a/docs/_docs/quick_start.md
+++ b/docs/_docs/quick_start.md
@@ -8,7 +8,7 @@ permalink: /docs/quick_start.html
 
 Prophet follows the `sklearn` model API.  We create an instance of the `Prophet` class and then call its `fit` and `predict` methods.  
 
-The input to Prophet is always a dataframe with two columns: `ds` and `y`.  The `ds` (datestamp) column should be of a format expected by Pandas, ideally YYYY-MM-DD for a date or YYYY-MM-DD HH:MM:SS for a timestamp. The `y` column must be numeric, and represents the measurement we wish to forecast.
+The input to Prophet is always a dataframe with two columns: `ds` and `y`.  The `ds` (datestamp) column should be in a format expected by Pandas, ideally YYYY-MM-DD for a date or YYYY-MM-DD HH:MM:SS for a timestamp. The `y` column must be numeric, and represents the measurement we wish to forecast.
 
 As an example, let's look at a time series of the log daily page views for the Wikipedia page for [Peyton Manning](https://en.wikipedia.org/wiki/Peyton_Manning).  We scraped this data using the [Wikipediatrend](https://cran.r-project.org/web/packages/wikipediatrend/vignettes/using-wikipediatrend.html) package in R.  Peyton Manning provides a nice example because it illustrates some of Prophet's features, like multiple seasonality, changing growth rates, and the ability to model special days (such as Manning's playoff and superbowl appearances). The CSV is available [here](https://github.com/facebook/prophet/blob/master/examples/example_wp_log_peyton_manning.csv).
 
@@ -39,6 +39,7 @@ df.head()
 
     .dataframe thead th {
         text-align: right;
+        text-transform: lowercase;
     }
 </style>
 <table border="1" class="dataframe">
@@ -110,6 +111,7 @@ future.tail()
 
     .dataframe thead th {
         text-align: right;
+        text-transform: lowercase;
     }
 </style>
 <table border="1" class="dataframe">
@@ -168,6 +170,7 @@ forecast[['ds', 'yhat', 'yhat_lower', 'yhat_upper']].tail()
 
     .dataframe thead th {
         text-align: right;
+        text-transform: lowercase;
     }
 </style>
 <table border="1" class="dataframe">


### PR DESCRIPTION
In the Python API section, the table headers are being rendered in uppercase (DS, Y) as opposed to lowercase (ds, y). I can confirm that the behavior is consistent across several platforms. I've proposed one sample fix that may help, but there could be other ways of formatting this correctly.