### PR TITLE
Adding title of cross-validation metric in plot

### DIFF
--- a/R/R/plot.R
+++ b/R/R/plot.R
@@ -497,6 +497,7 @@ plot_cross_validation_metric <- function(df_cv, metric, rolling_window=0.1) {
   gg <- (
     ggplot2::ggplot(df_none, ggplot2::aes_string(x = 'x_plt', y = metric)) +
     ggplot2::labs(x = paste0('Horizon (', dts[i], ')'), y = metric) +
+    ggplot2::ggtitle(paste0("Evolution of ", ggplot2::quo_name((metric)), " over horizon"))
     ggplot2::geom_point(color = 'gray') +
     ggplot2::geom_line(
       data = df_h, ggplot2::aes_string(x = 'x_plt', y = metric), color = 'blue'


### PR DESCRIPTION
Since cross-validation metrics are a handful and could probably be generated in bulk when having a lot of data series, having the metric in the title of the plot generated by `plot_cross_validation_metric` function by default will be a nice side-effect.

```R
prophet_performance$cross_val %>% 
  mutate(cov_plots = map(.,plot_cross_validation_metric,metric = 'coverage'), # this is the existing function
         mape_plots = map(.,plot_cross_validation_metric_custom,metric = 'mape')) # this is the proposed one
```

![image](https://user-images.githubusercontent.com/1923069/43902497-ee99a40a-9bf2-11e8-97fa-6e3c72d0f273.png)

