### PR TITLE
Update setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -106,6 +106,7 @@ setup(
     license='BSD',
     packages=['fbprophet', 'fbprophet.tests'],
     setup_requires=[
+        'pystan'
     ],
     install_requires=install_requires,
     zip_safe=False,


### PR DESCRIPTION
Add `pystan` to setup_requires: 
running the following command on a new virtualenv fails:
`pip install fbprophet --target=/tmp/foo --no-cache-dir`

Error: ImportError: No module named pystan

More context: 
https://stackoverflow.com/questions/52267470/pip-install-options-no-cache-dir-and-target-dont-work-well-together/52275092#52275092