### PR TITLE
Add pyproject.toml to help dependency managers

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["cython", "numpy", "pystan"]


### PR DESCRIPTION
Some dependency managers are able to use the information provided by the `pyproject.toml` file.

It helps to provide install/build-time dependencies information, which is currently the case with C/Cython-related packages.

More info on: https://www.python.org/dev/peps/pep-0518/