### PR TITLE
Fix duplicate kwarg algorithm when newton fallback is selected

### DIFF
--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -1047,7 +1047,7 @@ class Prophet(object):
                 params = model.optimizing(
                     dat, init=stan_init, iter=1e4, **kwargs)
             except RuntimeError:
-		kwargs.pop('algorithm')
+                kwargs.pop('algorithm')
                 params = model.optimizing(
                     dat, init=stan_init, iter=1e4, algorithm='Newton',
                     **kwargs

--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -1047,7 +1047,7 @@ class Prophet(object):
                 params = model.optimizing(
                     dat, init=stan_init, iter=1e4, **kwargs)
             except RuntimeError:
-                kwargs.pop('algorithm')
+                kwargs.pop('algorithm', None)
                 params = model.optimizing(
                     dat, init=stan_init, iter=1e4, algorithm='Newton',
                     **kwargs

--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -1047,6 +1047,7 @@ class Prophet(object):
                 params = model.optimizing(
                     dat, init=stan_init, iter=1e4, **kwargs)
             except RuntimeError:
+		kwargs.pop('algorithm')
                 params = model.optimizing(
                     dat, init=stan_init, iter=1e4, algorithm='Newton',
                     **kwargs


### PR DESCRIPTION
Address:
If kwarg algorithm is passed to fit() and stan fails to converge we should strip algorithm from kwarg before invoking newtwon fallback #700 