### PR TITLE
Apply non-duplicated colnames *before* coercing to a tbl_df

### DIFF
--- a/R/R/prophet.R
+++ b/R/R/prophet.R
@@ -1440,11 +1440,12 @@ predict_uncertainty <- function(m, df) {
             na.rm = TRUE)),
     t(apply(t(sim.values$trend), 2, stats::quantile, c(lower.p, upper.p),
             na.rm = TRUE))
-  ) %>% dplyr::as_data_frame()
+  )
 
   colnames(intervals) <- paste(rep(c('yhat', 'trend'), each=2),
                                c('lower', 'upper'), sep = "_")
-  return(intervals)
+
+  return(dplyr::as_data_frame(intervals))
 }
 
 #' Simulate observations from the extrapolated generative model.


### PR DESCRIPTION
I'm helping @krlmlr to assess the potential impact of changes in dev tibble. I selected this package as one of the experiments, because it's one of the revdeps with considerable download activity.

prophet depends on tibble via dplyr.

tibble is getting stricter about tibbles with unnamed columns or duplicate column names. There are, of course, ways to explicitly allow that or request name repair, but that code would depend on a specific version of tibble.

This PR makes prophet work with the current CRAN version of tibble (v1.4.2) *and* with the coming release.