### PR TITLE
Use row_number() instead of seq_len(n())

### DIFF
--- a/R/R/prophet.R
+++ b/R/R/prophet.R
@@ -885,7 +885,7 @@ make_all_seasonality_features <- function(m, df) {
 #' @keywords internal
 regressor_column_matrix <- function(m, seasonal.features, modes) {
   components <- dplyr::data_frame(component = colnames(seasonal.features)) %>%
-    dplyr::mutate(col = seq_len(n())) %>%
+    dplyr::mutate(col = dplyr::row_number()) %>%
     tidyr::separate(component, c('component', 'part'), sep = "_delim_",
                     extra = "merge", fill = "right") %>%
     dplyr::select(col, component)


### PR DESCRIPTION
This code will no more work with dplyr 0.8.0 if dplyr is not attached (c.f. https://github.com/tidyverse/dplyr/issues/4030).

```r
    dplyr::mutate(col = seq_len(n())) %>%
```

This can be simply fixed by adding `dplyr::` or moving dplyr from `Imports` to `Depends` to make sure it's attached. But, since `seq_len(n())` is equivalent to `row_number()`, this PR uses the latter, which seems a bit smarter.