### PR TITLE
Fix broken link to C++ compiler download

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@
 
 Prophet is a procedure for forecasting time series data based on an additive model where non-linear trends are fit with yearly, weekly, and daily seasonality, plus holiday effects. It works best with time series that have strong seasonal effects and several seasons of historical data. Prophet is robust to missing data and shifts in the trend, and typically handles outliers well.
 
-Prophet is [open source software](https://code.facebook.com/projects/) released by Facebook's [Core Data Science team](https://research.fb.com/category/data-science/).  It is available for download on [CRAN](https://cran.r-project.org/package=prophet) and [PyPI](https://pypi.python.org/pypi/fbprophet/).
+Prophet is [open source software](https://code.facebook.com/projects/) released by Facebook's [Core Data Science team](https://research.fb.com/category/data-science/). It is available for download on [CRAN](https://cran.r-project.org/package=prophet) and [PyPI](https://pypi.python.org/pypi/fbprophet/).
 
 ## Important links
-
 
 - Homepage: https://facebook.github.io/prophet/
 - HTML documentation: https://facebook.github.io/prophet/docs/quick_start.html
@@ -31,7 +30,7 @@ After installation, you can [get started!](https://facebook.github.io/prophet/do
 
 ### Windows
 
-On Windows, R requires a compiler so you'll need to [follow the instructions](https://github.com/stan-dev/rstan/wiki/Installing-RStan-on-Windows) provided by `rstan`.  The key step is installing [Rtools](http://cran.r-project.org/bin/windows/Rtools/) before attempting to install the package.
+On Windows, R requires a compiler so you'll need to [follow the instructions](https://github.com/stan-dev/rstan/wiki/Installing-RStan-on-Windows) provided by `rstan`. The key step is installing [Rtools](http://cran.r-project.org/bin/windows/Rtools/) before attempting to install the package.
 
 If you have custom Stan compiler settings, install from source rather than the CRAN binary.
 
@@ -44,7 +43,7 @@ Prophet is on PyPI, so you can use pip to install it:
 $ pip install fbprophet
 ```
 
-The major dependency that Prophet has is `pystan`.   PyStan has its own [installation instructions](http://pystan.readthedocs.io/en/latest/installation_beginner.html). Install pystan with pip before using pip to install fbprophet.
+The major dependency that Prophet has is `pystan`. PyStan has its own [installation instructions](http://pystan.readthedocs.io/en/latest/installation_beginner.html). Install pystan with pip before using pip to install fbprophet.
 
 After installation, you can [get started!](https://facebook.github.io/prophet/docs/quick_start.html#python-api)
 
@@ -52,7 +51,7 @@ If you upgrade the version of PyStan installed on your system, you may need to r
 
 ### Windows
 
-On Windows, PyStan requires a compiler so you'll need to [follow the instructions](http://pystan.readthedocs.io/en/latest/windows.html).  The key step is installing a recent [C++ compiler](http://landinghub.visualstudio.com/visual-cpp-build-tools).
+On Windows, PyStan requires a compiler so you'll need to [follow the instructions](http://pystan.readthedocs.io/en/latest/windows.html). The key step is installing a recent [C++ compiler](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
 
 ### Linux
 

--- a/docs/_docs/installation.md
+++ b/docs/_docs/installation.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
-docid: "installation"
-title: "Installation"
+docid: 'installation'
+title: 'Installation'
 permalink: /docs/installation.html
 subsections:
   - id: r
@@ -10,13 +10,13 @@ subsections:
     title: Using Python
 ---
 
-Prophet has two implementations: [R](#installation-in-r) and [Python](#installation-in-python).  Note the slight name difference for the Python package.
+Prophet has two implementations: [R](#installation-in-r) and [Python](#installation-in-python). Note the slight name difference for the Python package.
 
 <a href="#r"></a>
 
 ## Installation in R
 
-Due to [an upstream issue](https://github.com/r-lib/pkgbuild/issues/54) in pkgbuild, we recommend that you use `devtools` to install Prophet.  This is currently the only way to get the latest release.  We hope to resolve this in the near future.
+Due to [an upstream issue](https://github.com/r-lib/pkgbuild/issues/54) in pkgbuild, we recommend that you use `devtools` to install Prophet. This is currently the only way to get the latest release. We hope to resolve this in the near future.
 
 ```
 # R
@@ -34,7 +34,7 @@ After installation, you can [get started!](quick_start.html#r-api)
 
 ### Windows
 
-On Windows, R requires a compiler so you'll need to [follow the instructions](https://github.com/stan-dev/rstan/wiki/Installing-RStan-on-Windows) provided by `rstan`.  The key step is installing [Rtools](http://cran.r-project.org/bin/windows/Rtools/) before attempting to install the package.
+On Windows, R requires a compiler so you'll need to [follow the instructions](https://github.com/stan-dev/rstan/wiki/Installing-RStan-on-Windows) provided by `rstan`. The key step is installing [Rtools](http://cran.r-project.org/bin/windows/Rtools/) before attempting to install the package.
 
 If you have custom Stan compiler settings, install from source rather than the CRAN binary.
 
@@ -49,13 +49,13 @@ Prophet is on PyPI, so you can use pip to install it:
 $ pip install fbprophet
 ```
 
-The major dependency that Prophet has is `pystan`.   PyStan has its own [installation instructions](http://pystan.readthedocs.io/en/latest/installation_beginner.html). Install pystan with pip before using pip to install fbprophet.
+The major dependency that Prophet has is `pystan`. PyStan has its own [installation instructions](http://pystan.readthedocs.io/en/latest/installation_beginner.html). Install pystan with pip before using pip to install fbprophet.
 
 After installation, you can [get started!](quick_start.html#python-api)
 
 ### Windows
 
-On Windows, PyStan requires a compiler so you'll need to [follow the instructions](http://pystan.readthedocs.io/en/latest/windows.html).  The key step is installing a recent [C++ compiler](http://landinghub.visualstudio.com/visual-cpp-build-tools).
+On Windows, PyStan requires a compiler so you'll need to [follow the instructions](http://pystan.readthedocs.io/en/latest/windows.html). The key step is installing a recent [C++ compiler](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
 
 ### Linux
 

--- a/python/README
+++ b/python/README
@@ -31,7 +31,7 @@ Installation
   $ pip install fbprophet
 
 
-Note:  Installation requires PyStan, which has its `own installation instructions <http://pystan.readthedocs.io/en/latest/installation_beginner.html>`_.  On Windows, PyStan requires a compiler so you'll need to `follow the instructions<http://pystan.readthedocs.io/en/latest/windows.html>`_.  The key step is installing a recent `C++ compiler <http://landinghub.visualstudio.com/visual-cpp-build-tools>`_.
+Note:  Installation requires PyStan, which has its `own installation instructions <http://pystan.readthedocs.io/en/latest/installation_beginner.html>`_.  On Windows, PyStan requires a compiler so you'll need to `follow the instructions<http://pystan.readthedocs.io/en/latest/windows.html>`_.  The key step is installing a recent `C++ compiler <https://visualstudio.microsoft.com/visual-cpp-build-tools/>`_.
 
 Example usage
 -------------


### PR DESCRIPTION
Just fixing the broken link to Visual Studio for downloading the C++ compiler.
The linting on my VS Code tidied up a few extra things (mostly whitespace and [single quotation marks](https://github.com/facebook/prophet/compare/master...jennynz:fix-broken-link#diff-06aa6586b8b89c80a94fcdc10d704ec9R3)).
The broken link fixes are at:

- [docs/_docs/installation.md:L58](https://github.com/facebook/prophet/compare/master...jennynz:fix-broken-link#diff-06aa6586b8b89c80a94fcdc10d704ec9R58)
- [README.md:L54](https://github.com/facebook/prophet/compare/master...jennynz:fix-broken-link#diff-04c6e90faac2675aa89e2176d2eec7d8R54)
- [python/README:L34](https://github.com/facebook/prophet/compare/master...jennynz:fix-broken-link#diff-da667b01a64c904ed602f5665a9fda64R34).