### PR TITLE
Rather using Monday const from built-in calendar.py

### DIFF
--- a/python/fbprophet/hdays.py
+++ b/python/fbprophet/hdays.py
@@ -9,11 +9,11 @@
 from __future__ import absolute_import, division, print_function
 
 import warnings
-from calendar import Calendar
+from calendar import Calendar, MONDAY
 from datetime import date, timedelta
 
 from convertdate.islamic import from_gregorian, to_gregorian
-from holidays import MONDAY, WEEKEND, HolidayBase, easter, rd
+from holidays import WEEKEND, HolidayBase, easter, rd
 from lunardate import LunarDate
 
 


### PR DESCRIPTION
Latest version of `python-holidays` (0.9.9) changed the name of its `MONDAY` const to `MON`. Rather using the `MONDAY` const from the same library as the object that it is being used with (`calendar` module). 

Also, given [this constant](https://github.com/python/cpython/blame/3cdb5761c5d779b15e153cf33d52babbf56b5807/Lib/calendar.py) is 19 years old (!), I suspect it might not change in the near future.