### PR TITLE
Python: instantiate future before predicting

### DIFF
--- a/docs/_docs/uncertainty_intervals.md
+++ b/docs/_docs/uncertainty_intervals.md
@@ -60,7 +60,9 @@ forecast <- predict(m, future)
 ```python
 # Python
 m = Prophet(mcmc_samples=300)
-forecast = m.fit(df).predict(future)
+m.fit(df)
+future = m.make_future_dataframe(50, freq='MS')
+forecast = m.predict(future)
 ```
 This replaces the typical MAP estimation with MCMC sampling, and can take much longer depending on how many observations there are - expect several minutes instead of several seconds. If you do full sampling, then you will see the uncertainty in seasonal components when you plot them:
 


### PR DESCRIPTION
The original code had
```python
forecast = m.fit(df).predict(future)
```
Well. Where did that `future` come from? A reader will be confused, because the output of that will depend of which variable `future` points to. If following the previous examples, this will point to a different dataset, leading to unexpected results.

This proposal makes the origin of the `future` explicit.