### PR TITLE
Fix FutureWarning from Pandas 0.24.0.

### DIFF
--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -877,7 +877,7 @@ class Prophet(object):
         first = self.history['ds'].min()
         last = self.history['ds'].max()
         dt = self.history['ds'].diff()
-        min_dt = dt.iloc[dt.to_numpy().nonzero()[0]].min()
+        min_dt = dt.iloc[dt.values.nonzero()[0]].min()
 
         # Yearly seasonality
         yearly_disable = last - first < pd.Timedelta(days=730)

--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -877,7 +877,7 @@ class Prophet(object):
         first = self.history['ds'].min()
         last = self.history['ds'].max()
         dt = self.history['ds'].diff()
-        min_dt = dt.iloc[dt.nonzero()[0]].min()
+        min_dt = dt.iloc[dt.to_numpy().nonzero()[0]].min()
 
         # Yearly seasonality
         yearly_disable = last - first < pd.Timedelta(days=730)


### PR DESCRIPTION
Pandas release 0.24.0 has deprecated Series.nonzero(), apply suggested change.