### PR TITLE
Fixes bug #839 on computation of metrics with multiple cross validations

### DIFF
--- a/python/fbprophet/diagnostics.py
+++ b/python/fbprophet/diagnostics.py
@@ -232,7 +232,7 @@ def performance_metrics(df, metrics=None, rolling_window=0.1):
     return df_m.dropna() 
 
 
-def rolling_mean(x, w):
+def rolling_mean(x, rolling_window):
     """Compute a rolling mean of x
 
     Right-aligned. Padded with NaNs on the front so the output is the same

--- a/python/fbprophet/tests/test_diagnostics.py
+++ b/python/fbprophet/tests/test_diagnostics.py
@@ -117,9 +117,9 @@ class TestDiagnostics(TestCase):
         )
         self.assertEqual(df_none.shape[0], 16)
         # Aggregation level 0.2
-        df_horizon = diagnostics.performance_metrics(df_cv, rolling_window=0.2)
+        df_horizon = diagnostics.performance_metrics(df_cv, rolling_window=0.5)
         self.assertEqual(len(df_horizon['horizon'].unique()), 4)
-        self.assertEqual(df_horizon.shape[0], 14)
+        self.assertEqual(df_horizon.shape[0], 15)
         # Aggregation level all
         df_all = diagnostics.performance_metrics(df_cv, rolling_window=1)
         self.assertEqual(df_all.shape[0], 1)


### PR DESCRIPTION
Changed computations to grouping by cutoff, in this way the rolling averages are done within each cross validation set, and we avoid computing a metric that mixes data from different cross validations.