### PR TITLE
Feature Proposal with Python Draft: More flexible seasonality by specifying all periods

### DIFF
--- a/notebooks/customized_seasonality.ipynb
+++ b/notebooks/customized_seasonality.ipynb
@@ -1,0 +1,228 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "from fbprophet import Prophet\n",
+    "import pandas as pd\n",
+    "from matplotlib import pyplot as plt\n",
+    "import logging\n",
+    "logging.getLogger('fbprophet').setLevel(logging.ERROR)\n",
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "df = pd.read_csv('../examples/example_wp_log_peyton_manning.csv')\n",
+    "df['ds'] = pd.to_datetime(df['ds'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "playoffs = pd.DataFrame({\n",
+    "  'holiday': 'playoff',\n",
+    "  'ds': pd.to_datetime(['2008-01-13', '2009-01-03', '2010-01-16',\n",
+    "                        '2010-01-24', '2010-02-07', '2011-01-08',\n",
+    "                        '2013-01-12', '2014-01-12', '2014-01-19',\n",
+    "                        '2014-02-02', '2015-01-11', '2016-01-17',\n",
+    "                        '2016-01-24', '2016-02-07']),\n",
+    "  'lower_window': 0,\n",
+    "  'upper_window': 1,\n",
+    "})\n",
+    "superbowls = pd.DataFrame({\n",
+    "  'holiday': 'superbowl',\n",
+    "  'ds': pd.to_datetime(['2010-02-07', '2014-02-02', '2016-02-07']),\n",
+    "  'lower_window': 0,\n",
+    "  'upper_window': 1,\n",
+    "})\n",
+    "holidays = pd.concat((playoffs, superbowls))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Modeling Custom Seasonality Functions\n",
+    "We have previously modeled the effect of nfl sundays using additional regressors. We could also view the NFL weeks as having a completly different weekly seasonality that offseason weeks, which means that we would like to have two different weekly seasonality curves. This can be modeled with customized seasonalites by providing a DataFrame containg rows for each week telling if it is a NFL week or an off-season week. This is provided to the periods_df input parameter when constructing the model. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ds_start</th>\n",
+       "      <th>ds_end</th>\n",
+       "      <th>fourier_order</th>\n",
+       "      <th>period_name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2007-12-10</td>\n",
+       "      <td>2007-12-17</td>\n",
+       "      <td>3</td>\n",
+       "      <td>nfl_week</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2007-12-17</td>\n",
+       "      <td>2007-12-24</td>\n",
+       "      <td>3</td>\n",
+       "      <td>nfl_week</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2007-12-24</td>\n",
+       "      <td>2007-12-31</td>\n",
+       "      <td>3</td>\n",
+       "      <td>nfl_week</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2007-12-31</td>\n",
+       "      <td>2008-01-07</td>\n",
+       "      <td>3</td>\n",
+       "      <td>nfl_week</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2008-01-07</td>\n",
+       "      <td>2008-01-14</td>\n",
+       "      <td>3</td>\n",
+       "      <td>nfl_week</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    ds_start     ds_end  fourier_order period_name\n",
+       "0 2007-12-10 2007-12-17              3    nfl_week\n",
+       "1 2007-12-17 2007-12-24              3    nfl_week\n",
+       "2 2007-12-24 2007-12-31              3    nfl_week\n",
+       "3 2007-12-31 2008-01-07              3    nfl_week\n",
+       "4 2008-01-07 2008-01-14              3    nfl_week"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def get_week_type(date):\n",
+    "    if date.month > 8 or date.month < 2:\n",
+    "        return 'nfl_week'\n",
+    "    else:\n",
+    "        return 'offseason_week'\n",
+    "week_starts = pd.date_range(start=df['ds'].min(), end=df['ds'].max()+pd.DateOffset(days=366), freq=pd.DateOffset(days=7))\n",
+    "week_periods = pd.DataFrame({'ds_start': week_starts,\n",
+    "                             'ds_end': week_starts + pd.DateOffset(days=7),\n",
+    "                             'fourier_order': 3}) #Providing paramters here similarily to the holiday DataFrame\n",
+    "\n",
+    "week_periods['period_name'] = week_periods['ds_start'].apply(get_week_type)\n",
+    "week_periods.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = Prophet(holidays=holidays, periods_df=week_periods, \n",
+    "            weekly_seasonality=False)\n",
+    "m.fit(df)\n",
+    "future = m.make_future_dataframe(periods=366)\n",
+    "forecast = m.predict(future)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAf0AAAFBCAYAAAB9xHaGAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAIABJREFUeJzs3Xd4VGX2wPHvm15IJ7SEkNAJJAQIJTQLUhQFQVERBbuubVfdn4LKruuqq2vDtquuriKiggqIIIgirIC0UCQQemiBACG9Z5J5f3/cISQhlZSbSc7neebJ3Dt37pyBwLn3LedVWmuEEEII0fw5mB2AEEIIIRqHJH0hhBCihZCkL4QQQrQQkvSFEEKIFkKSvhBCCNFCSNIXQgghWghJ+kIIIUQLIUlfCCGEaCEk6QshhBAthJPZAdS31q1b69DQULPDEEIIIRrNtm3bzmmtA6s7rtkl/dDQUGJjY80OQwghhGg0SqljNTlOmveFEEKIFkKSvhBCCNFCSNIXQgghWohm16cvhBCiLIvFQmJiIvn5+WaHIurIzc2N4OBgnJ2dL+n9kvSFEKKZS0xMxMvLi9DQUJRSZocjLpHWmpSUFBITEwkLC7ukc0jzvhBCNHP5+fkEBARIwrdzSikCAgLq1GIjSV8IIVoASfjNQ13/HiXpCyGEEC2EJH0hhBCihZCkL4QQwq5cfvnlNa68+tJLLzVwNPZFkn49yLcU89nGo9zw79+48vW13D8vlvUHz5kdlhBCtHiS9MuSpF9HOQVF3PqfTfzluz1sO5ZGQnIOP+45w20fb+bt1QfNDk8IIUz3z3/+k7fffhuAxx57jCuvvBKA1atXc9ttt7Fq1SpiYmLo378/U6ZMITs7G4Bt27Zx2WWXMWDAAMaOHUtSUlKZ81qtVmbMmMGzzz5b4efOnDmTvLw8oqKimDZtGrNnz+att94qef2ZZ57h7bffZu3atYwcOZJJkyYRHh7OAw88gNVqBag0NnslSb+O3l1ziO3H0yt87Y2fDrArseLXhBCipRg5ciTr1q0DIDY2luzsbCwWC+vXryciIoIXXniBn3/+me3btxMdHc0bb7yBxWLhkUce4ZtvvmHbtm3cddddPPPMMyXnLCoqYtq0aXTv3p0XXnihws99+eWXcXd3Z+fOncyfP5+7776buXPnAsYFw1dffcW0adMA2LJlC6+//jpxcXEcPnyYRYsWce7cuQpjs2dSnKcOrFbNgq0nqjxmwdYTRAb7NlJEQgjR9AwYMIBt27aRlZWFq6sr/fv3JzY2lnXr1jFhwgTi4+MZNmwYAIWFhcTExLB//352797N6NGjASguLqZ9+/Yl57z//vu56aabylwIVCc0NJSAgAB27NjBmTNn6NevHwEBAQAMGjSIzp07AzB16lTWr1+Pm5tbhbHZM0n6dZBrKSY1p7DKY06k5TVSNEII0TQ5OzsTGhrKJ598wtChQ4mMjGTNmjUcPnyYsLAwRo8ezZdfflnmPXFxcfTu3ZuNGzdWeM6hQ4eyZs0annjiCdzc3Gocyz333MOnn37K6dOnueuuu0r2l5//rpRCa11hbPZMmvfrwMPZEW+3qq+b2nm7NlI0QgjRdI0cOZLXXnuNkSNHMmLECN5//32ioqIYMmQIGzZs4NChQwDk5uZy4MABevToQXJycknSt1gs7Nmzp+R8d999N9dccw1TpkyhqKio0s91dnbGYrGUbE+aNImVK1eydetWxo4dW7J/y5YtHDlyBKvVyoIFCxg+fHilsdkzSfp14OCguGFAcJXHTInu2EjRCCFE0zVixAiSkpKIiYmhbdu2uLm5MWLECAIDA/n000+ZOnUqkZGRDBkyhH379uHi4sI333zDU089Rd++fYmKiuK3334rc87HH3+c/v37c/vtt5cMvCvvvvvuIzIysqTv3sXFhSuuuIKbbroJR0fHkuNiYmKYOXMmffr0ISwsjEmTJlUamz1TWmuzY6hX0dHRuqbzN+tDRq6Fmz/cyL7TWRe95u/pwuanR+HsKNdWQgjz7N27l169epkdRpNgtVrp378/X3/9Nd26dQNg7dq1vPbaayxbtszk6Gqmor9PpdQ2rXV0de+VbFRHPh7OfP1ADI9d1Z3OgZ74ujuVNPmn5hTy0bojJkcohBACID4+nq5duzJq1KiShN/SyJ1+AziWksOYN3+loMiKq5MDP/5pJKGtPU2NSQjRcrWEO/3BgwdTUFBQZt+8efOIiIgwKaKGU5c7fRm93wA6BXjy2OjuvLxiHwVFVp5eHMf8ewbLKldCCNFANm/ebHYIdkGa9xvIPcPD6N3BG4DfDqfw9bZEkyMSQgjR0knSbyBOjg68PDkSB9vN/YvL95KcVVD1m4QQQogGJEm/AUUE+3DPCKPCU0aehb99v6eadwghRNOgtabY2rzGfAnp029wj13VnRW7kziRmseyXUlM6neGUb3amh2WEEJUKDmrgPfWHGLxjpNk5Fno3NqT24Z0YsbQUBwdZFySvZM7/Qbm7uLIS5MujB59dslusgsqrx4lhBBmSc4qYPK/N/Dpb0fJyDOq2CWcy+H5ZfH8acFOGmK21759+4iKiqJfv34cPnyYVq1a1ftnVCU0NJRz51rOUuimJn2l1Dil1H6l1CGl1MxKjrlJKRWvlNqjlPqisWOsDyO6BTK5fxAASRn5vLrSvis6CSGap7dWH+BEasXrhXz/+ynW7k+u989csmQJEydOZMeOHXTp0qXezy/KMi3pK6UcgfeAq4FwYKpSKrzcMd2AWcAwrXVv4E+NHmg9mT0+nABPFwA+23SMbcfSTI5ICCEusFo1S3acqvKYxTtOXvL5jx49Sq9evbj33nvp3bs3Y8aMYfny5cyZM4ePPvqIK664otpzPPjggyxduhQwauifXzDn448/5tlnnwXg888/Z9CgQURFRXH//fdTXFwMwKpVq4iJiaF///5MmTKF7OzsMufOy8tj3Lhx/Oc//7nk72gPzLzTHwQc0lonaK0Lga+AieWOuRd4T2udBqC1PtvIMdYbP08X/nKdcU2jNcxatIvCooprRQshRGMrLLZW2/WYklO3GUgHDx7koYceYs+ePfj6+pKWlsYDDzzAY489xpo1a6p9/8iRI1m3bh0AJ0+eJD4+HoD169czYsQI9u7dy4IFC9iwYQM7d+7E0dGR+fPnc+7cOV544QV+/vlntm/fTnR0NG+88UbJebOzs7nuuuu49dZbuffee+v0HZs6M5N+EFB6MfpE277SugPdlVIblFKblFLjKjqRUuo+pVSsUio2Obn+m5/qy4S+HbiseyAAB85k8/7/DpsckRBCGFydHOjgU/UStV0C69bfHhYWRlRUFAADBgzg6NGjtXr/iBEjWLduHfHx8YSHh9O2bVuSkpLYuHEjQ4cOZfXq1Wzbto2BAwcSFRXF6tWrSUhIYNOmTcTHxzNs2DCioqKYO3cux44dKznvxIkTufPOO5k+fXqdvp89MDPpVzQMtPwoESegG3A5MBX4SCnle9GbtP5Qax2ttY4ODAys90Dri1KKFyf1wcPFWNnp3V8OcejsxQv1CCFEY1NKMW1Ip8pfB6YOCqnTZ7i6Xlhq3NHRscolcSsSFBREWloaK1euLFmid+HChbRq1QovLy+01syYMYOdO3eyc+dO9u/fz3PPPYfWmtGjR5fsj4+P5+OPPy4577Bhw1ixYkWDDFRsasxM+olA6XVng4HyHUqJwHdaa4vW+giwH+MiwG4F+3nwxJgegNGcNmtRHFaZCyuEaALuHdGZq3q1qfC15yb0pld770aO6GIxMTHMmTOnJOm/9tprjBgxAoBRo0bxzTffcPas0ROcmprKsWPHGDJkCBs2bODQoUMA5ObmcuDAgZJzPv/88wQEBPDggw82/hdqZGYm/a1AN6VUmFLKBbgFWFrumCXAFQBKqdYYzf0JjRplA7hjaCh9g30A2Ho0jS+2HDc5IiGEABcnBz64PZr3b+vP2N5tGRTqz9RBISx7ZDgzhoaaHR5gNPEXFRXRtWtX+vfvT2pqaknSDw8P54UXXmDMmDFERkYyevRokpKSCAwM5NNPP2Xq1KlERkYyZMgQ9u0rO4tqzpw55Ofn8+STT5rxtRqNqavsKaWuAeYAjsB/tdYvKqWeB2K11kuVsULN68A4oBh4UWv9VVXnbAqr7NXE3qRMrntnPUVWjZerEz89fhntqulPE0KIS9ESVtlrSeqyyp6p8/S11j9orbtrrbtorV+07fuL1nqp7bnWWj+utQ7XWkdUl/DtSa/23tx/mVGiN6ugiL98t9vkiIQQQjR3UpHPRI9c2Y2w1p4ArIo/w8rdSSZHJIQQ5ouLiyMqKqrMY/DgwWaH1SxI7X0TuTk78o/JEdzy4SYAZn+3h5gurfFxdzY5MiGEME9ERAQ7d+40O4xmSe70TTakcwC3DDQmMSRnFfDyCinRK4QQomFI0m8CZl3di0AvY/7ql1uOszkhxeSIhBBCNEeS9JsAHw9n/jahd8n2rEVx5FuKTYxICNHiFeZAZhIUW8yORNQjSfpNxNV92jE6vC1gLGX53ppDJkckhGiRUhNg4Qx4OQTe6AmvdYOfnwNLfoN83Ntvv02vXr2YNm0aBQUFXHXVVURFRbFgwYIG+bym7NNPP+Xhhx9u0M+QgXxNhFKKv0/sw8bDKWQXFPHvtYcZH9menu3Mr4AlhGgh0o7Cx2Mgp9QaJnlpsP5NOLUTbvsWHBzr9SP/9a9/sWLFCsLCwti0aRMWi0UG8TUgudNvQtr5uPHUOKNEb5FVM/PbOIqlRK8QorGsfaVswi8tYQ3s/b5Op3/jjTfo06cPffr0Yc6cOTzwwAMkJCQwYcIEXnnlFW677TZ27txJVFQUhw8fZubMmYSHhxMZGcmf//xnAJKTk7nhhhsYOHAgAwcOZMOGDQBs2bKFoUOH0q9fP4YOHcr+/fsB2LNnT8lSu5GRkRw8eLDCWKDi5X/z8vIq/C5nz55lwIABAPz+++8opTh+3Kiu2qVLF3JzcyuNNScnh7vuuouBAwfSr18/vvvuu4vOv3z5cmJiYjh37lyd/swvorVuVo8BAwZoe1ZcbNWT/7VBd3pqme701DL93/UJZockhLBz8fHx1R9UXKz139tq/Vfvyh8Lbr/kGGJjY3WfPn10dna2zsrK0uHh4Xr79u26U6dOOjk5WWut9Zo1a/T48eO11lqnpKTo7t27a6vVqrXWOi0tTWut9dSpU/W6deu01lofO3ZM9+zZU2utdUZGhrZYLFprrX/66Sc9efJkrbXWDz/8sP7888+11loXFBTo3NzcSmM5cuSIdnR01Dt27NBaaz1lyhQ9b968Sr9TeHi4zsjI0O+8846Ojo7Wn3/+uT569KgeMmRIlbHOmjWr5LxpaWm6W7duOjs7W3/yySf6oYce0osWLdLDhw/XqampFX5uRX+fGJVsq82R0rzfxDg4KF6eHME1b6/DUqx59cf9jOndjiBfd7NDE0I0Z8WFUFTxXW2J/IxLPv369euZNGkSnp5GQbLJkyezbt26So/39vbGzc2Ne+65h/Hjx3PttdcC8PPPPxMfH19yXGZmJllZWWRkZDBjxgwOHjyIUgqLxRiAGBMTw4svvkhiYiKTJ0+mW7dulcYyYcKEWi3/O3ToUDZs2MCvv/7K008/zcqVK9Fal6wFUFmsq1atYunSpbz22msA5Ofnl7QSrFmzhtjYWFatWoW3d/1370rzfhPUra0XD13RFYDcwmKeXRzXIpZ8FEKYyMkV/LtUfUzbPpd8+tr+H+bk5MSWLVu44YYbWLJkCePGjQPAarWycePGkmVyT548iZeXF7Nnz+aKK65g9+7dfP/99+TnGwMPb731VpYuXYq7uztjx47ll19+qTKW2iz/O2LECNatW8exY8eYOHEiv//+O+vXr2fkyJFVxqq15ttvvy3Zf/z48ZJa+p07dyYrK6vMKoD1SZJ+E/WHy7vQtU0rANbsT+b7XVKiVwjRgJSCwQ9U/rqDE0TfdcmnHzlyJEuWLCE3N5ecnBwWL15cckdckezsbDIyMrjmmmuYM2dOyeC+MWPG8O6775Ycd35/RkYGQUFBgDEK/ryEhAQ6d+7Mo48+yoQJE9i1a1etY6nqO33++ed069YNBwcH/P39+eGHHxg2bFiVsY4dO5Z33nmn5OJjx44dJcd06tSJRYsWMX36dPbs2VPrmKojSb+JcnVy5JUbIlDK2P7b0j2k5RSaG5QQonkbeA/0u/3i/Y4uMPlDCKimJaAK/fv354477mDQoEEMHjyYe+65h379+lV6fFZWFtdeey2RkZFcdtllvPnmm4AxxS82NpbIyEjCw8N5//33AXjyySeZNWsWw4YNo7j4Qp2TBQsW0KdPH6Kioti3bx/Tp0+vdSyVCQ0NBSi5sx8+fDi+vr74+flVGevs2bOxWCxERkbSp08fZs+eXea8PXr0YP78+UyZMoXDhw/XOq6qmLq0bkOwl6V1a2r2kt3M23QMgBsHBPPalL4mRySEsDe1WlpXazixBXYtgNwUCOxhXAj4dmzYIEWN1WVpXRnI18Q9Oa4HP8Wf4XRmPt9sS+T6qCCGd2ttdlhCiOZKKQgZbDxEsyPN+02cl5szf7/+wuCZpxfHkVcoJXqFEKKxPPTQQxct9fvJJ5+YHdYlkTt9OzA6vC3jI9qzPC6J46m5zPn5ALOuqWFTnRBCiDp57733zA6h3sidvp3464RwvN2Ma7SP1h9h98lLny8rhGh5mtv4rZaqrn+PkvTtRBsvN54Zb9zdF1s1T327i6Jiq8lRCSHsgZubGykpKZL47ZzWmpSUFNzc3C75HNK8b0duiu7I4h0n2ZSQyp5Tmfx3wxHuG3npU2iEEC1DcHAwiYmJJCdXUldf2A03NzeCg4Mv+f2S9O2IUop/TI5k7JxfKSyy8sZPBxjXuz0hAR5mhyaEaMKcnZ0JCwszOwzRBEjzvp0Ja+3JH0d1AyDfYuVpKdErhBCihiTp26H7RnamZzsvANYfOse320+aHJEQQgh7IEnfDjk7OvDyDZE42Er0vrA8nnPZBeYGJYQQosmTpG+nojr6csdQo48uPdfC89/HV/MOIYQQLZ0kfTv2xJjuBPm6A7D091Os2X/W5IiEEEI0ZZL07ZinqxMvTrpQovfZxbvJKah87WchhBAtmyR9O3d5jzZcH9UBgJPpeby2ar/JEQkhhGiqJOk3A7OvDcfPwxmAT387yo7jaSZHJIQQoimSpN8MBLRyZfa14YCxFPasRXFYpESvEEKIciTpNxOT+gUxoltrAPadzuLDXxNMjkgIIURTI0m/mVBK8dKkCNydHQF4a/VBEpKzTY5KCCFEUyJJvxnp6O/B46O7A1BYZGXWojisVinRK4QQwmBq0ldKjVNK7VdKHVJKzaziuBuVUlopFd2Y8dmjO4eFEhHkA8DmI6ksiD1hckRCCCGaCtOSvlLKEXgPuBoIB6YqpcIrOM4LeBTY3LgR2icnRwf+MTkCR1uN3pd+2MvZzHyToxJCCNEUmHmnPwg4pLVO0FoXAl8BEys47u/APwHJXDXUJ8iHe0YYJXqz8ov469I9JkckhBCiKTAz6QcBpdueE237Siil+gEdtdbLqjqRUuo+pVSsUio2OTm5/iO1Q38a1Z1OAR4ArNh9mh/3nDY5IiGEEGYzM+mrCvaVjDpTSjkAbwJPVHcirfWHWutorXV0YGBgPYZov9xdHHlpUkTJ9l++201mvsXEiIQQQpjNzKSfCHQstR0MnCq17QX0AdYqpY4CQ4ClMpiv5oZ1bc2UAcEAnMks4J8r95kckRBCCDOZmfS3At2UUmFKKRfgFmDp+Re11hla69Za61CtdSiwCZigtY41J1z79Mz4XrRu5QLA55uOs/VoqskRCSGEMItpSV9rXQQ8DPwI7AUWaq33KKWeV0pNMCuu5sbXw4W/Xte7ZHvmt7soKCo2MSIhhBBmMXWevtb6B611d611F631i7Z9f9FaL63g2MvlLv/SXBvZnit7tgHgcHIO7605bHJEQgghzCAV+VoApRR/v74Pni5Gid5/rz3EgTNZJkclhBCisUnSbyGCfN35v7E9ALAUa2Z+u0tK9AohRAsjSb8FuT0mlH4hvgBsP57O55uPmRyREEKIxiRJvwVxdFC8PDkSZ0ejRMIrK/ZxKj3P5KiEEEI0Fkn6LUyPdl784bIuAOQUFjN7yW60lmZ+IYRoCSTpt0APXtGVzoGeAKzed5blcUkmRySEEKIxSNJvgdycHXl5cmTJ9nNL95CeW2hiREIIIRqDJP0WalCYP7cODgHgXHYhL/2w1+SIhBBCNDRJ+i3YzKt70sbLFYCFsYn8dvicyREJIYRoSJL0WzBvN2een9inZPvpRXHkW6RErxBCNFeS9Fu4cX3aMbZ3WwCOpuTy1uqDJkckhBCioUjSFzw/sQ9erk4AfPhrAvGnMk2OSAghREOQpC9o6+3GzGt6AlBs1cxctItiKdErhBDNjiR9AcDUgSEMCvUHYFdiBp9sOGJyREIIIeqbJH0BgIOD4qXJEbg4Gr8Sr686wInUXJOjEkIIUZ8k6YsSXdu04pEruwKQZynmGSnRK4QQzYokfVHG/Zd1oUdbLwB+PZDMkp0nTY5ICCFEfZGkL8pwcXLgHzdEoIyF+Hj++3hSsgvMDUoIIUS9kKQvLtI/xI8ZMaEApOVaeGG5lOgVQojmQJK+qNCfx/agg48bAIt3nOR/B5JNjkgIIURdSdIXFWrl6sTfr79QoveZxXHkFhaZGJEQQjQ9VqvmRGouJ9Pz7GLgs5PZAYima1Svtlwb2Z5lu5JITMvjjVUHePbacLPDEkKIJmHh1hO8t/YQx1KM6c3d2rTij1d149rIDiZHVjm50xdV+ut1vfFxdwbgvxuO8PuJdJMjEkII833wv8M8+e2ukoQPcPBsNg9/sYOFW0+YGFnVJOmLKgV6ufLM+F4AWDXMXBSHpdhqclRCCGGejFwLb/x0oNLXX/phb5NdsVSSvqjWlAHBDO0SAMDepEz+sy7B5IiEEMI8q/edoaCo8puf9DwLGw+nNGJENSdJX1RLKcVLkyJwdTJ+Xd76+SBHzuWYHJUQQpgjp6D6Qc1ZNTjGDJL0RY2EtvbksdHdASgosvL0oji7GKkqhBD1rXeQT/XHdPBuhEhqT5K+qLF7hocR3t74Rd6YkMLXsYkmRySEEI2vX0df+nb0rfT1y3sE0iWwVSNGVHOS9EWNOTk68MoNkTjYSvS+sDyes1n55gYlhBCNTCnFO1P74XT+P8NS+gR58/qUviZEVTOS9EWtRAT7cPfwMAAy84v42/fxJkckhBCN7+CZLIqsRhdnaIAHUweF8P5t/Vny4DACWrmaHF3lpDiPqLXHRndn5Z7TnEjNY/muJCZFneGq8LZmhyWEEI1m7sZjJc/n3NKPqCqa+5sSudMXtebh4sRLkyJKtmd/t5usfIuJEQkhRONJSM7mV9t6JH2Dfewm4YMkfXGJRnQLZHK/IACSMvJ57cf9JkckhBCNY96mC3f5020rktoLU5O+UmqcUmq/UuqQUmpmBa8/rpSKV0rtUkqtVkp1MiNOUbFnrw3H39MFMJq6es1eSY9nV3DbR5tZd1BW5RNCND85BUV8Y5u55O/pwvjI9iZHVDumJX2llCPwHnA1EA5MVUqVX81lBxCttY4EvgH+2bhRiqr4e7pwe8yF67A8SzEFRVbWHzrH7R9v4astx02MTggh6t/iHSdLCu/cMrAjbs6OJkdUO2be6Q8CDmmtE7TWhcBXwMTSB2it12itz69msAkIbuQYRRW01qyMS6r09ee+30N6bmEjRiSEEA1Ha81nG48C4KBg2hD7a3w2M+kHAaWXIkq07avM3cCKil5QSt2nlIpVSsUmJ0uzcmPZm5TF/jPZlb6eb7HyQ9zpRoxICCEazqaEVA7Y/s8bHd6WIF93kyOqPTOT/sVVDaDCuq5KqduAaODVil7XWn+otY7WWkcHBgbWY4iiKsnZBdUec64GxwghhD04f5cPMMPOBvCdZ+Y8/USgY6ntYOBU+YOUUlcBzwCXaa0lgzQhoQEe1R7TqQbHCCFEU3cqPY9V8WcA6NqmFTG2lUftjZl3+luBbkqpMKWUC3ALsLT0AUqpfsAHwASt9VkTYhRV6BTgyfCurSt9vZWLI2N7t2vEiIQQomF8sfk4xbYKfDNiOqFURY3VTZ9pSV9rXQQ8DPwI7AUWaq33KKWeV0pNsB32KtAK+FoptVMptbSS0wmTvHxDBB39K+7Xslg1iWm5Fb4mhBD2oqComC9ts5FauToxqb/9jik3tQyv1voH4Idy+/5S6vlVjR6UqJVgPw+WPTKChVtP8NPeM1iKraBhx4l0CoqsPDR/B0seGoa7i31NaxFCiPN+iEsiJceYiXRD/yBaudpvBfsa3ekrpR5WSvk1dDDCPvm4O3PvyM4svD+GxQ8O4+sHYhgU5g/A/jNZPLd0j8kRCiHEpZv724UKfLfb6QC+82ravN8O2KqUWmiromefnRmiUTg5OvD2Lf1KqvUtiD3Bou2JJkclhBC19/uJdHaeSAdgeNfWdG3TyuSI6qZGSV9r/SzQDfgYuAM4qJR6SSnVpQFjE3asnY8bb94cVbL97JLdHDpb+Zx+IYRoij7bWLrOvv0V4ymvxgP5tNYaOG17FAF+wDdKKSmNKyp0WfdAHrrCuC7MLSzmofnbySssNjkqIYSomZTsAr7fZcwkD/J1Z1Qv+19CvKZ9+o8qpbZh1L7fAERorf8ADABuaMD4hJ177KruDAq90L//t++lf18IYR8WxJ6gsMgKwG1DOuHoYP892zW9028NTNZaj9Vaf621tgBora3AtQ0WnbB7To4OvD31Qv/+V1tPsHiH9O8LIZq2omIr8zcZ0/RcnBy4eWDHat5hH6pM+kopf6WUPzAHyDq/XWo/Wuu9jRGosF/tfNx446a+JdvPLJb+fSFE07Z631lOpucBMKFvh5IbF3tX3Z3+NiDW9rP8I7ZhQxPNyeU92vDg5Rf69x/+Yjv5FunfF0I0Tc2hzn5Fqkz6WuswrXVn288yD0BG7otaeXx0dwaGGuUe9p2W/n0hRNN06GwWGw6lANAvxJeIYB9XvBhfAAAgAElEQVSTI6o/NR3I93y5bQfg8waJSDRb5fv3v9xygiU7TpoclRBClFV6ml5zusuHmg/kC1FKzQJQSrkCS4CDDRaVaLba+7iX6d9/enEch5Olf18I0TRk5Vv4dpsx2Lh1Kxeujmhei4bVNOnfCUTYEv/3wBqt9XMNFpVo1i7v0YY/XF52/r707wshmoJF20+SY6snMnVQCK5OzWvdkOpG7/dXSvUH+gFvATdj3OH/z7ZfiEvyxOjuRHcq3b8fb3JEQoiWTmvN3I1HAXB0UNw6OMTUeBpCdUsFvV5uOw0It+3XwJUNEZRo/pwcHXjn1n5c89Y60nItfLnlOEM6+zMxKsjs0IQQLdSGQykkJOcAMLZ3W9r7VLxsuD2rMulrra9orECEHbNa4fAvsP8HsFogJAZ6TwLnqv/BtPdx542bo7jzk60APL0ojj5BPnQJtO8FLVoca7Hx93/uALj7Q89rwK35jHYWLcf5u3yA6c1sAN95NVoUWCnVFngJ6KC1vlopFQ7EaK0/btDoRNOXnwlf3gLHNlzYt/0zWPsPuG0xtO5a5duv6NGGBy7rwvv/O0yOrX9/yUPDcHNuXv1ozVbSLlg4HdKOXNjn7AnjXoIBd5gWlhC1lZiWy+q9ZwDo0daLwbblwZubmg7k+xT4Eehg2z4A/KkhArJbqQnw66uw8mkj6RW0kBHpy58om/DPSz9uXAxYqx+g98QY6d+3SzkpMG9S2YQPYMmB7/8IB340Jy4hLsH8zcexauP59KGdaK4ryNfoTh9orbVeeH7anta6SCklw60BtIY1L8Kvr2EMc7D56S9w0zwIG2FaaLVSXARFeVBUAEX5xk9L6e3SD9trOecg7uvKz5ly0Phz6XoVuPuCu5/R7OtQ9i7e2TZ/f/zb0r9vF6xWKMiA9W9C7rnKj1v3BnQf23hxCXGJ8i3FfLXFqLPv5ebE9c34/56aJv0cpVQAtqymlBoCZDRYVPZk5xfGHX55eWnGne7DseDdvmbnKi66kFSLyiVcS6mEW1ECLp2sS7+3qveVfl030DXc2peMRwllJH53vzKPDu5+LO7lwmc7M0nXnvy4aCfRDkMJah904TjHmv66msBqhcyT4OgCXnaw/KbWUJht/J7mpUN+es2f52dS5gK3Mic2wcdjwL8L+IeBX9iFnx7+0EzvpIT9WbYribRcCwBTBnTE07UJ/19TRzX9Zo8DS4EuSqkNQCBwY4NFZU82vlv5a4XZRvOnf1g1d8+2bWtR48VtGm0kj/z0i5qFQ4G/OJfasajcW129L7QY1Obh5NqAX0fDlg/ht3cg44Sxr0N/uPJZ6Dqq4T73/Gdb8mzJ+HxCruZ5SeLOaJzftxObjUd5rt7gF3rxxYB/GHgHXdQaJERD0Voz97ejJdu3x3QyL5hGUKOkr7XerpS6DOgBKGD/+eV1W7TCHDhbTf9z8l7jYSYHZ3ByA2c346eTKzi5237atp1Lb5c+ror3OTrD4gcg52wlH6zg8lmAtt0tVvLQ1pp9j4JM45F+vHbf39mj3IVADS8cnD2qvxv9+TnYMKfsvlPbYf6NcMsX0OPq6uMrKqxd4i79vLigdn8Wl8LBCdx8L/zZnX+eebLi8RznuXgaLSBFeRe/VpAJp3cZj4s+zxn8Ol18MeAXZuyvZlaIELWx80Q6cSeNhuvLugcS1trT5IgaVk1H73tg3O130lrfq5TqppTqobVe1rDhNXEOzqAca9Y07uBUP4m2xu8rtb8h75queRW+voMKm3uH/REuf6rq91utUJhV5iIg9dwZ/r0yFpfCTHxVNmM7uxDiVnDxxYK1htedllzjkVnLOv+OLlVfFMDFCf88bYWlj8DIJ43+77zSd9rlErclp3ZxXRJVKmGfH19Rw+cunhVf/BRkwfsjLh7IB8bv+22LIXggZJ8xjkk9cvHPvNSL32u1QMoh41ERrw6lLgZCL+42EKIWytTZH9q87/IBlNbV980ppRZgLKc7XWvdRynlDmzUWkc1dIC1FR0drWNjG3HV3y9vhf3LK399wrvQd2rT7o+uq/0r4JcX4Uycse0dBEMfgcEPXHK/7S/7znDXp8bfo6eLI8seHVH2Clxro6WlqhaEkkd62e2K7jzthat3qaTsW/EdeEXJ3dUbHGo6WacW0k/Akj/A0XUX9vmEwPjXofuY6t+flw5pRy++GEg9YrtIq8HYgdLcfCpuIfAPMy4WGuLPQNit5KwChr38C4XFVkL8PVjz58txdLDPsSZKqW1a6+hqj6th0o/VWkcrpXZorfvZ9v2ute5b3XsbW6Mn/dNx8PFoo2+1vA794a4fwcml8eIxi9bGf9LFheDbqV5aF/6xYi8f/C8BgF7tvVn84ND6mb9vybv4QqAmFw2FWXX/bLjQ3VDR3fVF+0olcTefpnvxeHafUZzHIwBChtRP61JRgdGVU1ELQdrR2ndtOLpW3W1wKWM/tIYjv8LvX0LWafDvbNQnaB9Z+3OJRvfuLwd5bdUBAJ65phf3juxsckSXrr6T/m/AKGCD1rq/UqoL8KXWelDdQ61fjZ70ARJjYcVTcNL2uY4u0OcGGPey8R+2uCSWYiu3fLiJbcfSAJg2OIQXJ0WYF1CxpezFwsEfYV35StWlKAe4/n1jwFrpKYsNObCwpbBaISup8m6D/PRanlAZLVT+YRUPMKzo37HVCsv+BNvnXvza6L/DsEcv5ZuJRlJUbGX4K2s4nZmPm7MDm2aNwtfDfm/Q6jvpjwaexai7vwoYBtyhtV5bxzjrnSlJ/7zUBMhNM/6jkL7FenEyPY/xb68j3Tad5p2p/biub4dq3tVIiovg3QHGXWdFIm+ByR80akjCJje13IXA0QvbWadqfz53v4tbCM4drHxMB8BdqyBk8CV/BdGwVsQl8Yf52wG4ZWBHXr7Bvltn6jvpzwPigDwgAdista6iKod5TE36okGs3nuGu+caf6etXJ34/pHhTWeE7dm9MG/yxYkkZCjcugDcvM2JS1TOkgdpxypuJUg7VvMBotWJuAlu+E/9nEvUu1s+3MimBGMg6fJHh9O7g32vF1HTpF/TDsJPgOHAaKAzsFMp9avW+q06xChEjYzq1Zb7R3bmg18TyC4o4qH521lUX/37ddWmFzwSa1QmPL7J6NrpOd6oQihzzZsmZ3do09N4lGctNsamVDaOoCCz5p+TvK/eQhb1a//prJKEPzDUz+4Tfm3UdJ7+L0qp/wEDgSuAB4DegCR90Sj+PLYHW4+msv14OvFJmbywPJ4Xrjexf780F09j8JYsMGP/HBzBN8R4cFnZ17Qu222w/DFj2mJlZKXBJuuzjUdLnjfX1fQqU6P5K0qp1cAG4GZgPzBQa13BZbIQDcPZ0YF3bu2Pj7tRsu/zTcdZtusS+maFuFRKgWcABEdD5BSIvrvq48/thzOyeFRTk5FnYdF2o2ZHGy9XxvZuZ3JEjaumk1Z3AYVAHyASOD9XX4hGE+TrzutTLswSnfltHEfPNUZhGyEqMOyPENCt8tezz8JHo2DXwsaLSVTr222J5FmMgmq3Dg7Bxall1W6o0bfVWj+mtR4JTAJSMPr4azsnRog6uyq8LffZ5tJmFxTx0BfbybfIgo/CBB7+Rh2OQfcZxY8AWrWDmEcg1La6piUXFt0Lyx436g4IU1mtmnmbjAp8Tg6KWweFmBxR46tpGd6HgRHAAOAY8F9gXZVvEqKB/J+tf3/H8XT2nMrkxeV7+fv1fcwOS7REngFGKepxrxiVHs+v12AthjUvwbrXjONiP4ZTO+Cmz8C3o7kxt2DrDp3jiK11cFyfdrTxdjM5osZX03YNd+ANoKfWepTW+m9a61/q+uFKqXFKqf1KqUNKqZkVvO6qlFpge32zUiq0rp8p7J+zowPvlurfn7fpmPTvC3M5OJRdo8DBEUbNhlsXXhjQd2o7fDASDv1sXpwt3GelVtObMTTUtDjMVNPm/Ve11pu11vW2FqdSyhF4D7gao+jPVKVUeLnD7gbStNZdgTeBV+rr84V9k/59YRe6j4X7f4X2tt/VvFT4/EZY+7JR0U80muMpufyy31gRtFd7b6I7+ZkckTnMHMEwCDiktU7QWhcCXwETyx0zEThf4/IbYJRSl7iCi2h2rgpvy70jwgDp3xdNmF+oUZ2v/wzbDg1r/wFfTDGmAIpG8fnmY5yvRTcjphMtNZWYmfSDgBOlthNt+yo8xtbKkAEElD+RUuo+pVSsUio2OTm5gcIVTdGT43rSL8Soi77nVCYv/bDX5IiEqICzG0x4Gyb+y1jyGoxm/g9Gwslt5sbWAuQVFrNgq5FuvN2cmBhVPtW0HGYm/Yous8rXBK7JMWitP9RaR2utowMDA+slOGEfnB0deGdqv5L+/c82HmP5riSToxKiEv2mwd0/GfX7ATJOwH/HwdaPoQYl0cWlWfr7STLyjPLKNw/siLtLy62WaWbSTwRKD2MNBsqPxio5RinlBPgA0h4mygj28+C1Uv37T327i2Mp0r8vmqj2kXDfWugx3tguLoTlj8Pi+6FQfm/rm9aaub8Z0/SUgtuGdDI5InOZmfS3At2UUmFKKRfgFmBpuWOWAuc7wm4EftE1WSFItDijw9tyz/Cy/fsFRdK/L5ood1+4ZT5c9TdjCWaAXQvgo6vg3CFzY2tmth1LIz7JWDPhih5t6BTQRBbrMolpSd/WR/8w8COwF1iotd6jlHpeKTXBdtjHQIBS6hDwOHDRtD4hzntyXE+iOhr9+7tPZvLScunfF02YUjD8TzB9KXi2MfadjYcPL4f48vc/4lLN3Xis5Pn0mJZ9lw81XFrXnsjSui1bYlou17y1jsx8Y3bpv6b155qI9iZHJUQ1MpPgmzvh+MYL+2IehqueA0dns6Kye2cz8xn68i8UWTWhAR788sTlODg0z1H7NV1at2UVHRbNXrCfB6/fFFWy/dQ30r8v7IB3e5jxvZHoz9v4LsydAFmnzYvLzn2x5ThFVuPG9vaY0Gab8GtDkr5odkaHt+VuW/9+lvTvC3vh6AxjX4Qpc8HFy9h3/Dd4fwQcXW9ubHaosMjK/M3HAXB3duTGAcEmR9Q0SNIXzdJT43rSt1T//j9+2GdyRELUUO/rjdH9bWwFSnPOGnf8G96SaX218OOe0yRnGYscTeofVDKtt6WTpC+aJRcnB96d2g9vN2NNqU9/O8qKOJm/L+xE665wz88QebOxrYvhp7/AgtsgP8Pc2OzEZxuPljyXAXwXSNIXzVZH/7Lz95/8ZhfHU3JNjEiIWnDxhEkfwPjXwdHF2LdvmTG6/3ScqaE1dXtOZbD1aBoAg8P86dnO2+SImg5J+qJZG9O7HXcNk/59YaeUgoH3wJ0rwcdWyyw1wZjPv/MLc2NrwuaVmqbXUlfTq4wkfdHszby6J32DjeVN405mSP++sD/BA+C+/0GXUcZ2UT4s+QN8/0ew5JsbWxOTnlvIkp0nAWjn7cbo8LYmR9S0SNIXzZ6LkwPv3tq/TP/+yt3Svy/sjGcATPsaLp9FybIk2z6F/46BtKMmBta0fB2bSL7FWLZ42uAQnB0lzZUmfxqiRejo78Grpfr3/0/694U9cnCEy2fCtG/A3bYefNLv8MFlcGCVubE1AVarZt4mo2nf2VFxy6AQkyNqeiTpixZjbOn+/fwiHv5S+veFnep2Fdz/K3Tob2znp8MXU+CXF8Dacn+n/3cgmeOpxsX8+Ij2BHq5mhxR0yNJX7Qopfv3dyVK/76wY74hcNdKiL77wr5fX4XPJ0POOfPiMtHcjUdLnk+XAXwVkqQvWpTz/fteZfr3pcypsFNOrnDtGzDpQ3ByN/YlrIUPRsKJraaG1tiOnsth7f5kACKCfOhnK84lypKkL1qcjv4evHpj6f793zmRKv37wo71vRnuXQ3+XYztzJPwydWw+YMWU8XvfF8+GMV4lJI6+xWRpC9apHF92nHnsFDA1r//xXYKi6zmBiVEXbTtbZTv7XWdsW21wIon4du7oSDbzMgaXG5hEQtjTwDg5+HMdX07mBxR0yVJX7RYs67uVdK//3tiBv9YsdfkiISoIzdvuGkejHkRlKOxb/e38J8rIXm/ubE1oCU7TpFlW0775oEhuDk7mhxR0yVJX7RY5fv3P9lwlB/3SP++sHNKwdCH4Y5l0Kqdse/cfvjwCti9yNzYGoDWuqTOvoMy5uaLyknSFy2a0b8fWbL9f19L/75oJjoNNab1dRpubFty4Js7YcVMKCo0N7Z6tOVIKvtOZwEwqldbOvp7mBxR0yZJX7R44/q05w7b9J5M6d8XzYlXW5j+HQz704V9m/8Nn46HjJPmxVWPPitdZz8m1LxA7IQkfSGAWdf0JLJU//7LK2T+vmgmHJ1g9N/g5vngalttLnGLMa0vYa2podXV6Yx8Vtq65DoHejKsa4DJETV9kvSFAFydHHl3an+8XI3+/f9uOCL9+6J56XWtMbq/bR9jO/cczJsEv74GVvts2fpi8zGKrcaUxBkxoTJNrwYk6QthExLgwT+lf180ZwFd4O6foO+txra2wi9/h6+mQl6aubHVUkFRMV9sOQ6Ap4sjk/sHmRyRfZCkL0QpV0eU69//cof074vmxcUDrv8XXPcWONpq0x9YaSzak/S7ubHVwsrdpzmXbQxIvGFAMF5uzo0fhNZG5cNfX4N1b0DSrsaPoZYk6QtRzqxrehIRZOvfP5HOKyulf180M0rBgDvg7h+NGv4A6cfgo9Gw/TNTQ6upub8dLXk+PaZT4weQlwafTYSPrzJaS1b/DT4YAV/eCoU5jR9PDUnSF6IcVydH3rv1Qv/+x+uPsEr690Vz1KEf3Pc/6DbW2C4ugKWPwJKHwJJnbmxViEvMYPvxdACGdgmgaxuvxg9i0X1w5H8X79+/HJY91vjx1JAkfSEqUL5//8/Svy+aKw9/mPoVXPksYBsIt/Nz+Hg0pCaYGlplzhfjAZhuxjS9M/FwcFXlr8d9DRmJjRdPLUjSF6ISV0e0Z4at2TAzv4hHpH9fNFcODjDy/+D2xeBhm/Z2Og4+uBz2/WBqaOWl5RTy3e+nAOjg48ZVvdo03IcVWyDlMBz8GTZ/CCuegvlT4LMJVb9PW+HEloaLqw6czA5AiKbs6fG92HY8jd0nM9l5Ip1/rtzHs9eGmx2WEA2jyxVw/zr4egYkboWCDGNk//DH4IpnjTn/JlsQe6Lk4nvakE44Odbx3rWo0BjPkJpgPFIOX3iefhx08aWd19GlbnE1EPP/BoVows7371/79nqyCor4aP0RBoX5M6Z3O7NDE6Jh+ATBHT/AqmdhywfGvvVvQmIs3PhfaNWAd9bVKLZq5tkq8Lk4OnDLwI41e6MlH9KO2pJ5qaSemmA0w+vatOAp8GoPWacqP8TZE8JG1OKcjUeSvhDV6BTgySs3RvLg/O2A0b//Qwdvgv2kxrdoppxc4Jp/QsdBsPRRo27/0XXw/gi4aS6EDDElrF/2neVkujHA8Nq+7Qlo5XrhxcIcI7GnlEvqqUcg8ySga/5BygF8OoJ/Z6O2gX/nCw/fTuDsBitnwaZ/Vfz+4Y+Bm88lf8+GpLSuxR+EHYiOjtaxsbFmhyGaob98t7ukzndUR18W3h+Di5MMi2nptNYcOJPN2ax8Ovl7EhLQzC4Gz+6DhbfDuQPGtoMTjH4ehjxoTP1rRPf+Zw2nEuLppE4ze6gb7YtPGUk9NQGykmp3MuUIfp3Av1xS9+9sTGN0qqZ53loMa/8Bm/4NhdnGPjdfGP4nY62DRv6zUUpt01pHV3ucJH0haibfUsyN7//G7pOZANw7Ioxnxkv/fku2KzGdWYvi2HMqs2Tf8K6tefmGiObVElSQZdzx7ym1NG/4RJjwrlHOd99yY4pfh/7Q5UpjYOClyksve5due1507jBOecm1O5ejC/iFlkvqYcZPn47gWA8FfQqy4NQOo3WgQ3+j+JEJJOkL0QCOpeSU9O8D/Gd6NKPD25oclTDDobPZTHxvPTkFFw/0CvJ154dHR+DjYUKVuIaiNWz5EH58GqzG7z9uvpCfXva4wF4w9UsjuVYmN7VcE3ypR25K7eJycgO/sLIJ/fzDJxgcHGt3PjslSV+IBrJ8VxIPfWH07/u4O7P80eHN665O1Mifv/6db7ZVPhd75tU9eeCyLo0YUSM5vhm+vqPqgWz+XeCOZZB+ouLEXv5CoRra2YMDhYEkWNtwxqkD066+HOfArkZi9+pQt5aFZqKmSd+UgXxKKX9gARAKHAVu0lqnlTsmCvg34A0UAy9qrRc0bqRCXGx8ZHs2JXRi3qZjZORZeOTLHSy8Pwbnuk4dEnYhLaeQuJMZLNtVRdIDfoo/0zyTfshguOcneCsKrJaKj0k9DG/0qt15XVpd3Ldue3y+O5/ZS+MBeGh4F5wH9azjl2i5zBq9PxNYrbV+WSk107b9VLljcoHpWuuDSqkOwDal1I9a69pdIgrRAJ4Z34vtx9PYcyqTHcfTufbt9VisVlwcHRgd3pbpMaEEerlWfyLRpKXnGgk+7mQGcYnGz8S0mpWntRQ340JOeemVJ/yquPpAQEWJvQt4tq5w8JvWmrmbfgXAQcG0wSbU2W9GzEr6E4HLbc/nAmspl/S11gdKPT+llDoLBAKS9IXp3JyN+fvj3vqVfIuV/WeySl7bdzqLhbEnWHBfDKGtPU2MUtRGRq6F3acy2JWYwe6TGew6mc6J1EuvP9+rnXc9RtfE1KTwTOse0HtS2Wlv7n61HtW+8XAKh84ao+PHhLejg6/7pUQsbMxK+m211kkAWuskpVSV1R6UUoMAF+BwJa/fB9wHEBISUs+hClGx1l6uVDYk5kxmAbMWxfHlfebMZxZVy8izsMd2B7/rpJHkj6VUv7ZCBx83+gT5EBnsg4NS/PPH/ZUeu/bAWQ4nZ9MlsFV9ht40BHQ17s5TK/wv2XDdHOg0tM4fNXfj0ZLn04fKXX5dNVjSV0r9DFRUtuyZWp6nPTAPmKF1xWWTtNYfAh+CMZCvlqEKcUl+iEuioIpa/BsTUli+6xQDw/wJbOWKauR5u8KQlW9h98lM4k6mE3cyk7jEdI7WIMG383YjItiHiCCfkp+tW5XtsmndypW/LN1NvuXC74GjgmJtXPhNeX8jn9wxkL4dfev9e5nKwQFGzTYG9FWk62gIianzx5xMz+On+DMAdGvTipjOAXU+Z0vXYElfa31VZa8ppc4opdrb7vLbA2crOc4bWA48q7Xe1EChCnFJEmuw6t5DX+wAwN3ZkY7+7oT4exDs50GIv+0R4EFHPw/cXVrGtKKGlpVvYc+pTKN53tZMn3Cu+rXN23q7Gsk9yJeIYG/6BPnQxsut2vfdNLAjY3q3ZXlcEslZBXQK8GB4l0D+uGAHvx1OITWnkKn/2cQHtw9gRLfA+viKTUfvSVBcBD//1VbxDqPZP/JmuPqVeilOM3/TMay227jpQ0PlwrkemDJlTyn1KpBSaiCfv9b6yXLHuAArgO+11nNqem6Zsicayxebj/P04rh6OVfrVq6E2C4KQvw9CPa/cGHQ1tsNRwf5z668nIIi9pzKZFdiuq0PPoMj53Iq7XI5L9DLlcggn5Jm+oggH9p4V5/ga6OgqJjHFuzkh7jTADg7Kt68OYprIzvU6+c0CcVFcGq7UQa3XYQxIK8e5FuKGfryL6TmFOLl6sSmp0fh6SqV4yvTpKfsAS8DC5VSdwPHgSkASqlo4AGt9T3ATcBIIEApdYftfXdorXeaEK8QFxkf2Z6/L4snz1LxKlyd/D2Y2C+IxNRcjtseZ7MKKjz2XHYB57IL2H784nGqLo4OBPm509Hfo+TCoKOfh7Ed4IG3WzMqAFOJnIIi4pMyLwyyS0wnoQYJvnUrVyKCvIkI9iXCluTb1nOCr4irkyPvTO2Pr8duvth8HEux5pEvd5CWU8jtZqz/3pAcnYwa/fVs+a4kUnMKAbhhQLAk/HoixXmEqIPvdp7ksQU7S5ogz/N1d2bB/TH0aOdVZn++pZjENNtFQEoux1PzOJGWywnbRUFuYe2X8fT1cC57IWB7dPR3p4Ovu93VD8gtLCL+VGaZaXKHkrOrTfABni5EBPuU3MVHBPvQztvN1CZhrTVv/nyQt1cfLNn3x1Hd+NNV3aSpuhoT313P74kZAKx+4rLmOSCyHjX1O30hmoWJUUEE+3nw0boEYo+llczTv2dEWIVV+tycHenaxouubbwuek1rTUpOIcdTjYuAE6VaCE6k5pGUkXfRxQVAeq6F9FyjD7s8BwUdfC+0DoQEXLgw6Ojnjr+nS52TT7FVs+5gMoeTc/DzcGZ0eFu8atj6kFdYTHySMbguzjbY7tDZ7Aq/Z2n+ni62PvgLg+za+5ib4CuilOLx0d0J8HThue/3oDW8tfogqTmFPDeht3TbVGLnifSShD+iW2tJ+PVIkr4QdTSgkx8DOg2o83mUUrRu5UrrVq70D/G76PXCIiun0vOMi4C03JKLg/MXBRl5FxdLsWpITMuzFZS5uKa5p4tjudaBCz+D/dxxc656gGH8qUwenL+tzGh4TxdHZl8bzi2Dyk6fzbcYCb70ILuDZ7MpribD+3k4l+l/jwj2pUMTTPBVmTE0FD9PF55YuBNLsWbepmOk5hbyxk19cXWSQZzlffbb0ZLnM5pbd4jJJOkLYSdcnBwIbe1ZacGfjFxLycVA2QuCXBLT8iiqILnmFBaz73QW+05nVXBGY1R76YuB0s8dHRS3f7yZFFu/a+lzzlwUR3aBBVcnR2MufGLNEryPuzORwbZBdrZm+mA/d7tK8JWZ0LcDvu7O3D9vG3mWYpbvSiIj18L7tw+glfRXlziXXcCyXcYyucF+7lzRs8oyLqKWpE9fiBag2Ko5nZnP8ZRSFwOlWgvOZRdWf5JynBxUhRcSNeXt5mRrmr8wyK65JPiq7Diexp2fbiU912iZ6Rvsw3/vGEhAKynbDPDemkO8ait6NOvqntzfHNcvaHgCW+0AABhVSURBVACyyp4QosZyCopITMursJXgeGpulUWIasLLzemiPvgQf49mn+Arc+hsFrd/vIWkjHwAOgd68tldg1r8ao1FxVZG/nMNpzLycXVyYNOsUfh51qDkr5CBfEKImvN0daJHO6+LZhuAMcAwOavgQutAinFx8PPeMxWOIyhtzs19ieroR4i/Bw4yaK1E1zZefPuHodz+8WYOJ+eQkJzDjf/eyGd3D6J724v/DlqKn/ee5ZTtQmhiVAdJ+A3AvubyCCEanVKKNt5uRIf6M6lfMH+8qhuv39SXx0d3r/J9I7sHcn2/YEJbe0rCr0AHX3e+eWAoUbYSvacz85ny/ka2HUur5p3N12cbj5Y8ny4D+BqEJH0hxCW5YUAwIf4VN0c7OSgevbJrI0dkf/w8XZh/z2BGdjdK9GbkWbjto82s2V9hZfJm7eCZLH47bMwwGdDJjz5BPiZH1DxJ0hdCXJJWrk58ce9gBoX5l9kf5OvOh9MHEB3qX8k7RWmerk58ND2aCX2NEr15lmLunRvLkh0nTY6scX228VjJ8+kxsppeQ5E+fSHEJQv282Dh/TEcOJPF4bPZ+Hm6MDDUX4rO1JKLkwNzbo7C39OFT387SpFV86cFO0nNKeSu4WFmh9fgMvMtfLs9ETBKJ1/dp73JETVfkvSFEHXWva1Xix6AVh8cHBR/vS6cAE8XXv/pAADPL4snJaeAP4/p0axnOizallhSgvrWwSG4OEkjdEORP1khhGgilFI8MqobL07qU7Iy7XtrDjNrURxFxXWbNtlUWa26pGnfyUExbXBINe8QdSFJXwghmphpgzvx3q39cbEtlvTV1hM89MV28itZ0dGebTh8joRzOQCM7dOuUVZBbMkk6QshRBN0TUR7Pr1zIJ4uRm3+H/ec4Y5PtpCVX3VtBHsz97cLA/ikzn7Dk6QvhBBN1NCurfnqvhgCbEVqNiWkcsuHm0jOKjA5svpxIjWX1fvOANCznRcDQy9eaErUL0n6QgjRhEUE+/DNH4YS7OcOwJ5Tmdz4/m8cL7Wyob36fPMxzleCnx4T2qwHKzYVkvSFEKKJC2vtybd/GEoP2wyJYym53PD+b+xNyjQ5skuXbylmwdYTgLE2w/X9OpgcUcsgSV8IIexAW283Ft4fQ3Qnowk8+f/bu/MwK4p7jePfl2FkB2UNuIC74oqMChijxiUxxqgRjRuLxv3J4k3UxxvNFWNuzKIxUW+MG4qCGxojSYziEsSwKfuiiEZRZFdRkH2p+0fVgRZmhgFm5szhvJ/nmWf69OlTXVXdp39d3X2qlqzk7HtG8fr7n+Y5Z1tnyKQ560caPLtsVxrv4F+Q1wYHfTOzAtGicSmPfP9Ivp7GmF+yYg29HhjDi2/Oz3POtkwIgQEjZ65/3aube+CrLQ76ZmYFpNEOJdzTqyvfPWxnAFauWcflA8fx5NhZec5Z1Y3/8DOmzYm3Jo7dtw2dWjfJc46Kh4O+mVmBKS2px609D+GSo2MXvWvXBa59ajL3vPqfPOesarKj6flnerXLQd/MrADVqyeuP6Uz/33yfuvn3fLP6fzqubcIuUfi66AFS1bw3JS5AOzWsjHHpBEGrXY46JuZFbDLjtmT3/Y8mNwYR/cOf4+rB0+us932Pv76LFavjSclvbt3pJ4HZ6pVDvpmZgXu7LJduadXGQ3SQDVPj/+Iyx4Zx/JVdavb3tVr1zFoTOyBr2FpPc7qumuec1R8HPTNzLYDJ3Zux8MXHUGzBvGnby9PX0Dv/mP4fFnd6bZ36LT5zF8cexM8o8vOtGhcmuccFR8HfTOz7cSRe7Tiicu607ppAwDemLmI7907ivmLV+Q5Z9GAUTPXT/fq1ilf2ShqDvpmZtuRzh2a85cretCxVWMAps9bwpl3j+T9NJJdvrw1d/H6joSO6NSSzh2a5zU/xcpB38xsO7Nbq8YMvrw7ndvHwPrRouX0vHskU2d/nrc8PTxqw2h6vXu4M558cdA3M9sOtW3WkMcv68aRu7cE4JOlqzjn3tGM/M/HtZ6Xz5et5q8TZqd8NeAbB3yl1vNgkYO+mdl2qnnDUgZcdAQndW4HwBcr19C3/xs8P3VureZj8LhZLF8df0lw/pEdKS1x6MkX17yZ2XasYWkJfzr/MM45PP48btXadVw5aDyPjvmwVta/bl3gkdHx0n5piTj3SP9ML58c9M3MtnP1S+pxy3cP4spj9wRgXYCfPTOFu155p8Z773v1nYV88MkyAE4+sD1tmzWs0fVZ5Rz0zcyKgCSu/eZ+3HDK/uvn3Tp0Bjf97U3Wrau5wP9wZjS9Pn6AL+/yEvQltZT0oqR30v+dKlm2uaTZku6qzTyamW2PLj56D27/3iHUT93fPjRyJlc9MZFVa6q/296ZHy9l2IyFABzQoTmH7Vbhod5qSb5a+tcBL4cQ9gZeTq8rcjPwaq3kysysCJzRZRfu611Gw9IYAoZMmsPFD49l2ao11bqegaM/IHf3oE/3TkjuZz/f8hX0TwMGpOkBwOnlLSSpK9AOGFpL+TIzKwrH7deWQRd3o0Wj2BXu8BkLOe++MSxauqpa0l+2ag1Pjp0FwI6NS/nOoR2qJV3bNvkK+u1CCHMB0v+2Gy8gqR5wG3DN5hKTdKmksZLGLly4sNoza2a2PeracScGX96drzSPD9dNnPUZZ90zijmfLd/mtJ+dOIfFK+KVg++V7UrD0pJtTtO2XY0FfUkvSZpazt9pVUziSuC5EMKszS0YQrg3hFAWQihr08ZjM5uZVdU+7Zrx1BXd2aN1EwDeXfAFPe8eybsLvtjqNEMIDEgP8ElwQTc/wFdX1FjQDyGcEEI4sJy/Z4H5ktoDpP8LykmiO/ADSTOBW4Hekn5dU/k1MytWu+wUu+09eJcWAMz5fAVn/XkkE2d9tlXpjf1gEdPnLQHg+P3asmvLxtWWV9s2+bq8PwTok6b7AM9uvEAI4fwQwm4hhE7A1cDDIYTKHvgzM7Ot1KppAx69pBtH7dUKgEXLVnPefaMZPmPLb5kOyPxMr3f3TtWUQ6sO+Qr6vwZOlPQOcGJ6jaQySffnKU9mZkWtaYP69O97OKcc1B6AZavW8v0BbzBk0pwqpzF/8QqenzoPgD1aN+Gre7Wukbza1qmfj5WGED4Bji9n/ljg4nLmPwQ8VOMZMzMrcg3ql3DHuV3YqUkpA0d/yOq1gR8/PoFFS1fRp0enzX7+0TEfsiZ19tOre0fq1fPP9OoS98hnZmZfUlJP3Hzagfz4+L0BCAFuHDKN3784o9Jue1etWcejr8c+/RvvUMKZXXeplfxa1Tnom5nZJiTxXyfuwy9OO4Bcnzp3vPwOP392Kmsr6Lb3+WnzWLhkJQDfPWxnmjcsra3sWhU56JuZWYV6d+/EHed0obQkRv6Boz/kR49NYOWatZss+7Af4KvzHPTNzKxSpx7Sgf59D6fxDrGDnX9MmctFD73BFys3dNs7dfbnjP1gEQDd92jFPu2a5SWvVrm8PMhnZmaF5ei92/DYJd3o++DrLFq2mhHvfkLPu0fSZbcdGfb2Qj75YuX6ZT2aXt3llr6ZmVXJIbvuyODLe9ChRey2d/q8JTz2+izmfr6CVWs33Of/6NNt78bXaoaDvpmZVdlebZvy9JU91l/qL88tz0+vlv77rfo56JuZ2RYpkVi2atMH+XLWrgs8M2F2LebIqspB38zMtsiCJSs3v8ziFbWQE9tSDvpmZrZFOuzYiJLN9LTnQXbqJgd9MzPbIi2b7MA3D/hKhe83qF+P07vsXIs5sqpy0Dczsy1243c6s3vrJpvML5H4bc+Dad20QR5yZZvj3+mbmdkWa9usIc/+4CgeG/Mhz02dx/JVazh01x3p06MTB3Roke/sWQVU2eAJhaisrCyMHTs239kwMzOrNZLGhRDKNrecL++bmZkVCQd9MzOzIuGgb2ZmViQc9M3MzIqEg76ZmVmRcNA3MzMrEg76ZmZmRcJB38zMrEg46JuZmRUJB30zM7Mi4aBvZmZWJLa7vvclLQQ+yGMWWgMf53H9+ebyu/zFWv5iLju4/Pkuf8cQQpvNLbTdBf18kzS2KoMebK9cfpe/WMtfzGUHl79Qyu/L+2ZmZkXCQd/MzKxIOOhXv3vznYE8c/mLWzGXv5jLDi5/QZTf9/TNzMyKhFv6ZmZmRcJB38zMrEg46CeSgqRHMq/rS1oo6e/VlH4/SVdXR1rVRVIrSRPT3zxJszOvd6iB9f1b0qHVnW4l67td0lWZ1y9Iuj/z+jZJP6liWjW6/ST1lXRXTaWfWU9F2/wzSW/WwvprpZzbQtLaTB1NlNSpnGU6SHqqgs8Pk1Snf7ol6XpJ0yRNTmU8spJl+0rqUA3rrLP1siX1sQVp1rljPkD9fGegDlkKHCipUQhhOXAiMDvPeapRIYRPgEMh7qDAFyGEW/Oaqeo1EjgL+IOkesTOM5pn3u8BXFXeB7dXFW3zFNi2+gRXUv0QwprqyGMdsDyEUOHJaSrrHKBnLeap2kjqDnwbOCyEsFJSa6Cyk/y+wFRgzhaso2D2h62oj4Lmlv6X/RM4JU2fCzyWe0NSS0l/TWeCoyUdnOb3k9Q/ncW+J+lHmc9cL+ltSS8B+2bmXyLpDUmTJD0tqbGkZpLel1SalmkuaWbudW2StJekiZnX10m6IU3vnVrM4yQNl7RPmn+OpKmpTP9K8xpLGpzq7HGgYSbNeyWNTWfX/5PmfUPS4MwyJ0t6chuKMoIY2AEOIB64lkjaSVIDYH9ggqRr0vaYLOmmzPor2n7DJP1G0uuSZkg6Os0vkfS7TFqXpfntU11NTHWUW/7C9PlXgaMy6Z8qaYykCZJektROUj1J70hqk5apJ+nddICqLiWS7kvbZKikRpnylqXp1pJmpum+afv+DRhaQOXcYuWUtZOkqem9RpIeT9v8CaBR5nN3Z/bzm9K84yU9k1nmREl/qcXitAc+DiGsBAghfBxCmCPpf9K+OzV9PyWpJ1AGDErbtVE6LrVOeS+TNCxN90ufGwo8XED1UlF9VFbOwj3mhxD8F3/B8AVwMPAUMThNBI4F/p7evxO4MU1/HZiYpvsRW5QNiC3JT4BSoCswBWhMbF2+C1ydPtMqs95fAj9M0w8Cp6fpS4HbarH8/TL52ytXvvT6OuCGNP0vYM80fRQwNE2/BbRL0zum/9cC96bpLsBa4ND0umX6Xx94DehMPAl9O1c/wJPAydtYrpnAbsBlwOXAzcC3Ut6HAycRf2qjtP6/A1/bzPYblts2Ka2XMtssV08NgLHA7sBPgevT/BKgGfFA8yHQhtiqGAHclZbZiQ2/rLk4s64bgavS9EnA09W4zTsBazLb50nggkx5y9J0a2Bmmu4LfJTZlnWynFtRL2uJ3/+JwDMVlLUTMDVN/wTon6YPTvWYq6/c8iWpHg9O+9p0oE1671Hg1FosX9NUthnAn4BjsnlN04/k8pTd/pnvVOs0XQYMy+xP44BGhVQvldRHZeUs2GO+W/oZIYTJxC/zucBzG739VeIXgRDCK0ArSS3Se/8IIawMIXwMLADaAUcTDxjLQgiLgSGZtA6U9JqkKcD5xFYowP3AhWn6QuIOUWdI2hHoBjyteCXg/4Dcvb4RxLP7i9lwBelrwECAEMIEYFomuXMljQfGE1vcnUMI64hf9PMktSR+iYZuY7Zzrf0ewKj0l3s9khhUTgImpLzsB+xN5dsPINcCGUfcZ0jp9E51MwZoldJ6A7hQ8XL6QSGEJcCRxIPIwhDCKuCJTNq7AC+k/eMaNuwf/YHeafoiqn//eD+EkLvCky1XZV4MIXyapgulnJuzPIRwaPo7IzM/W9as7H4+GZicee/stJ9PIJavc4hH+EeAC9J3qjvxKmOtCCF8QfxuXQosBJ6Q1Bc4Ll15mUJs2BxQcSoVGhLi7VEokHqppD4qU7DHfN/T39QQ4FZiK79VZr7KWTbXycHKzLy1bKjXijpBeIh4djcp7VzHAoQQRqTLhscAJSGEqVuR/+qwhi/f+mmY5ol4Gay8+52XEA/w3wYmKd3+oJw6kLQ38GPgiBDCZ5IGsuHSf3/g6TT9RAhh7TaWZSQxwB9EvLw/i9giXZzWdSxwSwjhno3yeFV5ec/IbfPs9hbxDP6FjReW9DXiraNHJP0urb+i9O8Efh9CGCLpWGLLghDCLEnzJX2dWNfnV5K/rbHxfpy7HJvdHxryZUtzEyGE4QVSzq21tJL3ytvPdweuBg4PISyS9BAb6u9B4G/ACmBwqOX73+l7NQwYlgLRZcTWdlmq/35suq1zqrQ/5Fa18YfrYr2UUx99qLycBXvMd0t/U/2BX4QQpmw0fzjp4JMOUB+ns7mKDAfOSPe1mgGnZt5rBsxN9242PqA9THyWIJ+t/HlAB8V73w1JzzmEEBYR830GrL/fekj6zB4hhNHAz4FFwM58uc4OYcPZbXNgCbBYUnvgG7kVhxBmEUequo74RdlWI4gnIp+GENamllquFTEKeAG4SFLTlM+dJbWl8u1XkReAKzL36PaR1ERSR2BBCOE+4AHgMOKVgGMVn6YvJT5wmNOCDQ+R9tloHfcTW09PVsMJUVXNJLaEoJKH17aDcm6t7H5+IDF4QtzPlwKfS2oHnJz7QIgPAs4BbqB69vMqk7RvOvHOOZR4Ww3g4/RdyG7nJcRjVs5MNuwPZ1ayqoKolwrq4wOqXs6cgjjmu6W/kRDCR8Afy3mrH/CgpMnAMjY9SG2czvj08MpE4g70WubtnxMPhh8Q7wFlv1CDiPd8HiNPQggrJP2KeLn2PSD7U65zgLtTS2AH4oF5EnB7OoMX8T7/VEnvAQNSnY0n3uMmTb9JbHm/RwzMWY8CzUMIM6qhOFOI990e3Whe03Rpbqik/YFRkiA+23HBZrZfRe4nXhIfr5jYQuB04ln9NZJWp/R7hxDmpjocBcwl1klJSqcfMFjSbGA08bmAnCHEg0NtnhTeCjwpqRfwSiXLHUthl3Nr3c2GY8NE4HWA1KrL3dYqbz8fRLx/XeM/ldxIU+DOdAl9DfHe86XAZ8Tvxkzidz/nIeDPkpYTT5ZvAh6Q9DPicawihVIvFdXH/lStnEDhHPPdDW8do/i07GkhhF75zku+SPozMCqEMCDfealrFJ+ivz2EcHS+81KTiqGciv0VTAghPJDvvNQlxVYvtX3Md0u/DpF0J/FS17fynZd8SQ/BLQJ+tLlli42k64ArqDv3uGtEMZRT0jjiJe6f5jsvdUmx1Us+jvlu6ZuZmRUJP8hnZmZWJBz0zczMioSDvpmZWZFw0DcrcqrC6GcqgNHxzGzzHPTNzMyKhIO+WYGRdK3SyF6Sbpf0Spo+XtJASSdJGiVpvOLIcLneBrtKelVxhMQXUm+I2XTrSRog6Zfp9YWqodHxJD0k6Q5JIxVHKuuZ5jeV9HLK+xRJp6X5nSRNl3S/4ihwgySdIGlEWu8RabkmiiOgvZHyd1o1V79ZQXPQNys8w4mDe0Ac/atp6t7zq8Tevm4ATgghHEbsBfEn6f07gZ4hhK7E7qb/N5NmfWLPYDNCCDekE4KbiMH+ROIoiDn/BrqFELoAjwPXpsGSBrLht/UnAJNSr4cVaZ/y/G3g12neCuCMlPfjgNtS74YQR3/8I7E71/2A89LnrwZ+lpa5HnglhHB4+vzvJDWpJA9mRcWd85gVnnFA19S/90pi17ZlxBOBIcQAPSLFyh2IXeDuCxwIvJjmlxC7xc25h9jPfe5EYP3oeACpe9F90nu7EEcia5/Sfz/N7w88C/yBqo2O99d0svBm6oMdYjfOv1IcuGcdcQyH3Hvv58bEkDQNeDmEEBQHSOmUljkJ+I6kq9PrhsShld/aTF7MioKDvlmBCSGsljSTOBTnSOKQpccBexID8IshhHOzn5F0EDAthNC9gmRHEodWvS2EsCK3qgqWra7R8bIjleVa8+cDbYCumXI2LGf5dZnX6/jySIdnhhDexsw24cv7ZoVpOPGy9nDiwB6XEwf6GA0cJWkvAEmNJe1DHEWtjaTuaX6ppOx46Q8AzxEHwKlP/kbHa0EcqW+1pOOAjlv4+ReAH+ZuCUjqshV5MNtuOeibFabXiPfER4UQ5hPvhb+WLsf3BR5Lo5uNBvYLIawiDpf6G0mTiCcIPbIJhhB+T7xV8Agwn9iCHwW8lObn9COeHLxGHAY5awhx1LKtHR1vEFAmaSyx1T99Cz9/M1AKTJY0Nb02s8R975tZtSmG0fHMCpnv6ZtZtSiG0fHMCp1b+mZWYyRdz5efBwAYnPmVgJnVIgd9MzOzIuEH+czMzIqEg76ZmVmRcNA3MzMrEg76ZmZmRcJB38zMrEj8P5f56qRbj8ZSAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 576x360 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import seaborn as sns\n",
+    "from matplotlib.ticker import PercentFormatter\n",
+    "forecast['weekday_name'] = forecast['ds'].dt.weekday_name\n",
+    "plot_df = forecast.melt(id_vars='weekday_name', value_vars=['nfl_week', 'offseason_week'],\n",
+    "                        value_name='weekly', var_name='week_type')\n",
+    "plot_df = plot_df[plot_df.weekly != 0]\n",
+    "sns.pointplot(x='weekday_name', y='weekly', hue = 'week_type', data=plot_df)\n",
+    "plt.gcf().set_size_inches(8,5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The custom period feature enables modeling of seasonality in a large variety of additional cases. For example to use different daily seasonality on weekends and weekdays for subdaily data. Addtionaly, it lets use use exact days in month and year rather than approximating it as 30.5 and 365.25\n",
+    "\n",
+    "The concept of a period DataFrame can in future be further extended to allow Half Fourier Series, for when the underlying seasonality is discontinuous, for example between a restaurant closing and opening. Additionally period breaks could be added, to for example avoid applying seasonality when there's also an holiday on that day. \n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
I've have created a suggestion for a new implementation of seasonality, by predefining a dataframe with every period similarly to how Holidays Work. In the notebook in this PR the DataFrame contains every week in the data with information if it's a NFL week or an off-season week. My implementation then fit two different seasonalities depending on the period name

There are many additional use-cases such as having different daily seasonality on weekends and weekdays for sub-daily data. Additionally, it lets use use exact days in month and year rather than approximating it as 30.5 and 365.25

The concept of a period DataFrame can in future be further extended to allow Half Fourier Series, for when the underlying seasonality is discontinuous, for example between a restaurant closing and opening. Additionally period breaks could be added, too for example avoid applying seasonality when there's also a holiday on that day. 

I'm curious about your thoughts on this, such as if this is a valid method, if you are interested in implementing it fully, or if there's a better way of dealing with these cases.

![image](https://user-images.githubusercontent.com/36272238/53242707-d2769000-36a5-11e9-967e-a21f537fedda.png)
