### PR TITLE
Update requirements.txt

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,7 +1,7 @@
 Cython>=0.22
 pystan>=2.14
 numpy>=1.10.0
-pandas>=0.20.1
+pandas>=0.23.4
 matplotlib>=2.0.0
 lunardate>=0.1.5
 convertdate>=2.1.2


### PR DESCRIPTION
pandas>=0.23.4 is required to not encounter the following error when passing a holidays argument, since earlier in earlier version pandas the concat does not have a sort argument.

File "/usr/local/lib/python3.6/dist-packages/fbprophet/forecaster.py", line 454, in construct_holiday_dataframe
all_holidays = pd.concat((all_holidays, holidays_to_add), sort=False)
TypeError: concat() got an unexpected keyword argument 'sort'