### PR TITLE
Python: add pystan to setup_requires

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -109,8 +109,7 @@ setup(
     author_email='sjtz@pm.me',
     license='MIT',
     packages=find_packages(),
-    setup_requires=[
-    ],
+    setup_requires=["pystan>=2.14"],
     install_requires=install_requires,
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
Fixes #201 and #401

The issue is that the setup script imports pystan, so if you happen to try to install the package in an environment where pystan is not previously installed, it will fail.