### PR TITLE
Add validation to prevent user setting fourier_order <= 0 (#980)

### DIFF
--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -647,6 +647,8 @@ class Prophet(object):
             ps = float(prior_scale)
         if ps <= 0:
             raise ValueError('Prior scale must be > 0')
+        if fourier_order <= 0:
+            raise ValueError('Fourier Order must be > 0')
         if mode is None:
             mode = self.seasonality_mode
         if mode not in ['additive', 'multiplicative']:

--- a/python/fbprophet/tests/test_prophet.py
+++ b/python/fbprophet/tests/test_prophet.py
@@ -557,6 +557,12 @@ class TestProphet(TestCase):
         with self.assertRaises(ValueError):
             m.add_seasonality(name='trend', period=30, fourier_order=5)
         m.add_seasonality(name='weekly', period=30, fourier_order=5)
+        # Test fourier order <= 0
+        m = Prophet()
+        with self.assertRaises(ValueError):
+            m.add_seasonality(name='weekly', period=7, fourier_order=0)
+        with self.assertRaises(ValueError):
+            m.add_seasonality(name='weekly', period=7, fourier_order=-1)
         # Test priors
         m = Prophet(
             holidays=holidays, yearly_seasonality=False,


### PR DESCRIPTION
This PR adds validation to Prophet.add_seasonality() which raises a ValueError if the user attempts to add custom seasonality with fourier_order set <= 0. Closes #980 