### PR TITLE
[BUG/TST] Add validation to prevent fourier.order <= 0; addresses #980

### DIFF
--- a/R/R/prophet.R
+++ b/R/R/prophet.R
@@ -697,7 +697,7 @@ add_regressor <- function(
     mode <- m$seasonality.mode
   }
   if(prior.scale <= 0) {
-    stop("Prior scale must be > 0")
+    stop("Prior scale must be > 0.")
   }
   if (!(mode %in% c('additive', 'multiplicative'))) {
     stop("mode must be 'additive' or 'multiplicative'")
@@ -760,7 +760,10 @@ add_seasonality <- function(
     ps <- prior.scale
   }
   if (ps <= 0) {
-    stop('Prior scale must be > 0')
+    stop('Prior scale must be > 0.')
+  }
+  if (fourier.order <= 0) {
+    stop('Fourier order must be > 0.')
   }
   if (is.null(mode)) {
     mode <- m$seasonality.mode

--- a/R/tests/testthat/test_prophet.R
+++ b/R/tests/testthat/test_prophet.R
@@ -521,6 +521,10 @@ test_that("custom_seasonality", {
                          holiday = c('special_day'),
                          prior_scale = c(4))
   m <- prophet(holidays=holidays)
+  expect_error(
+    add_seasonality(m, name="incorrect.fourier.order", period=30, fourier.order=-10),
+    "Fourier order must be > 0."
+  )
   m <- add_seasonality(m, name='monthly', period=30, fourier.order=5)
   true <- list(
     period = 30, fourier.order = 5, prior.scale = 10, mode = 'additive',
@@ -529,10 +533,12 @@ test_that("custom_seasonality", {
     expect_equal(m$seasonalities$monthly[[name]], true[[name]])
   }
   expect_error(
-    add_seasonality(m, name='special_day', period=30, fourier_order=5)
+    add_seasonality(m, name='special_day', period=30, fourier.order=5),
+    "already used for a holiday."
   )
   expect_error(
-    add_seasonality(m, name='trend', period=30, fourier_order=5)
+    add_seasonality(m, name='trend', period=30, fourier.order=5),
+    "is reserved."
   )
   m <- add_seasonality(m, name='weekly', period=30, fourier.order=5)
   # Test priors


### PR DESCRIPTION
In reverse order of importance, this change addresses:
  - #980, by adding validation to ensure that `fourier.order` > 0
  - changes all the tests that `expect_error` using the argument
    `fourier_order`, as the argument is named `fourier.order`, so
    the intent of the test is to validate the holiday names rather
    than to check the use of the correct argument name

Tested these changes by using `devtools::testthat()`.

Resolves: #980