### PR TITLE
New Plotly Components Plot

### DIFF
--- a/python/fbprophet/plot.py
+++ b/python/fbprophet/plot.py
@@ -823,8 +823,15 @@ def get_forecast_component_plotly_props(m, fcst, name, uncertainty=True, plot_ca
     mode = 'lines'
     if name == 'holidays':
         fcst = fcst[fcst[name] != 0].copy()
-        text = fcst.merge(m.holidays, how='left', on='ds')['holiday']
         mode = 'markers'
+        # Combine holidays into one hover text
+        holiday_features, _, _ = m.make_holiday_features(fcst['ds'], m.holidays)
+        holiday_features.columns = holiday_features.columns.str.replace('_delim_', '', regex=False)
+        holiday_features.columns = holiday_features.columns.str.replace('+0', '', regex=False)
+        text = pd.Series(data='', index=holiday_features.index)
+        for holiday_feature, idxs in holiday_features.iteritems():
+            text[idxs.astype(bool) & (text != '')] += '<br>'  # Add newline if additional holiday
+            text[idxs.astype(bool)] += holiday_feature
 
     traces = []
     traces.append(go.Scatter(


### PR DESCRIPTION
This PR would add a new Plotly plot of all the components, which intends to match the recently created Plotly plot of the forecast.

To view it in action, check out: https://nbviewer.jupyter.org/github/Olof-Hojvall/prophet/blob/bdc93bd2896488a7cd80a11d66b23b20d3480469/notebooks/Plotly%20Components.ipynb

Suggestion of changes are always appreciated. There are many new features possible using Plotly, but to keep it a bit more simple this first PR mainly seeks to replicated existing matplotlib plot apart from some changes to holidays. 

There are many possible variants of the components plot, making it a bit harder to test. I've not really tested anything else that what's in that notebook, and some help testing other examples would be appreciated.