### PR TITLE
Replace functools.reduce with pd.concat to concatenate dataframes

### DIFF
--- a/python/fbprophet/diagnostics.py
+++ b/python/fbprophet/diagnostics.py
@@ -136,7 +136,7 @@ def cross_validation(model, horizon, period=None, initial=None):
         ], axis=1))
 
     # Combine all predicted pd.DataFrame into one pd.DataFrame
-    return reduce(lambda x, y: x.append(y), predicts).reset_index(drop=True)
+    return pd.concat(predicts, axis=0).reset_index(drop=True)
 
 def prophet_copy(m, cutoff=None):
     """Copy Prophet object


### PR DESCRIPTION
`cross_validation` currently concatenates dataframes using `functools.reduce`. However, `pd.concat` is more than 4x as fast at concatenating dataframes than `functools.reduce`. Given that `cross_validation` may be called many times for certain use cases (e.g., grid search over hyperparameters) it would be beneficial to use the faster `pd.concat` method to concatenate dataframes. 

```python
import pandas as pd
from functools import reduce

data = {
    "ds": {
        0: pd.Timestamp("2016-01-11 00:00:00"),
        1: pd.Timestamp("2016-01-18 00:00:00"),
        2: pd.Timestamp("2016-01-25 00:00:00"),
        3: pd.Timestamp("2016-02-01 00:00:00"),
        4: pd.Timestamp("2016-02-08 00:00:00"),
    },
    "y": {0: 0.95, 1: 0.96, 2: 0.95, 3: 0.97, 4: 0.95},
    "floor": {0: 0, 1: 0, 2: 0, 3: 0, 4: 0},
    "t": {0: 0.03, 1: 0.01, 2: 0.019, 3: 0.029, 4: 0.038},
    "y_scaled": {0: 0.54, 1: 0.55, 2: 0.55, 3: 0.57, 4: 0.51},
}

df = pd.DataFrame(data)

list_of_df = [df.copy() for _ in range(100)]

%%timeit
pd.concat(list_of_df, axis=0).reset_index(drop=True)
# 24.5 ms ± 509 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

%%timeit
reduce(lambda x, y: x.append(y), list_of_df).reset_index(drop=True)
# 117 ms ± 1.79 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```