### PR TITLE
Feature/disable uncertainty

### DIFF
--- a/python/fbprophet/diagnostics.py
+++ b/python/fbprophet/diagnostics.py
@@ -101,6 +101,10 @@ def cross_validation(model, horizon, period=None, initial=None):
             msg += 'Consider increasing initial.'
             logger.warning(msg)
 
+    predict_columns = ['ds', 'yhat']
+    if model.uncertainty_samples:
+        predict_columns.extend(['yhat_lower', 'yhat_upper'])
+
     cutoffs = generate_cutoffs(df, horizon, initial, period)
     predicts = []
     for cutoff in cutoffs:
@@ -130,7 +134,7 @@ def cross_validation(model, horizon, period=None, initial=None):
         yhat = m.predict(df[index_predicted][columns])
         # Merge yhat(predicts), y(df, original data) and cutoff
         predicts.append(pd.concat([
-            yhat[['ds', 'yhat', 'yhat_lower', 'yhat_upper']],
+            yhat[predict_columns],
             df[index_predicted][['y']].reset_index(drop=True),
             pd.DataFrame({'cutoff': [cutoff] * len(yhat)})
         ], axis=1))
@@ -234,6 +238,8 @@ def performance_metrics(df, metrics=None, rolling_window=0.1):
     valid_metrics = ['mse', 'rmse', 'mae', 'mape', 'mdape', 'coverage']
     if metrics is None:
         metrics = valid_metrics
+    if ('yhat_lower' not in df) or ('yhat_upper' not in df) and ('coverage' in metrics):
+        metrics.remove('coverage')
     if len(set(metrics)) != len(metrics):
         raise ValueError('Input metrics must be a list of unique values')
     if not set(metrics).issubset(set(valid_metrics)):

--- a/python/fbprophet/diagnostics.py
+++ b/python/fbprophet/diagnostics.py
@@ -238,7 +238,7 @@ def performance_metrics(df, metrics=None, rolling_window=0.1):
     valid_metrics = ['mse', 'rmse', 'mae', 'mape', 'mdape', 'coverage']
     if metrics is None:
         metrics = valid_metrics
-    if ('yhat_lower' not in df) or ('yhat_upper' not in df) and ('coverage' in metrics):
+    if ('yhat_lower' not in df or 'yhat_upper' not in df) and ('coverage' in metrics):
         metrics.remove('coverage')
     if len(set(metrics)) != len(metrics):
         raise ValueError('Input metrics must be a list of unique values')


### PR DESCRIPTION
This pull request is related to issue #1082. <br/>
When the user does not care about uncertainties, it is possible to set `uncertainty_samples=0` to speed up the calculations by a factor of about 2 compared to `uncertainty_samples=1000`. Doing this, prophet's `predict` method still calls some methods that calculate an uncertainty. <br/>
I added some `if`-statements that check if the model's `uncertainty_samples` is set to `0` or `False`. In that case, the methods that calculate an uncertainty are not called. This speeds up the calculation by another factor of about 3 making it all in all 6 times faster compared to `uncertainty_samples=1000` when there is no need for uncertainty intervals. <br/>
Since prophet's `plot` module expects uncertainty intervals, I changed that module as well, that no uncertainty intervals are plotted when the model's `uncertainty_samples` equals `0` or `False`.