### PR TITLE
Add python 2/3 trove classifiers

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -120,6 +120,12 @@ setup(
         'test': TestCommand,
     },
     test_suite='fbprophet.tests',
+    classifiers=[
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.7',
+      ],
     long_description="""
 Implements a procedure for forecasting time series data based on an additive model where non-linear trends are fit with yearly, weekly, and daily seasonality, plus holiday effects. It works best with time series that have strong seasonal effects and several seasons of historical data. Prophet is robust to missing data and shifts in the trend, and typically handles outliers well.
 """


### PR DESCRIPTION
Clearly identify this project as supporting python 2 and 3.
This is useful for utility programs like [caniusepython3](https://github.com/brettcannon/caniusepython3#how-do-you-tell-if-a-project-has-been-ported-to-python-3).