### PR TITLE
Add test and fix for issue #891

### DIFF
--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -262,8 +262,8 @@ class Prophet(object):
                     raise ValueError('Found non-boolean in column ' + condition_name)
                 df[condition_name] = df[condition_name].astype('bool')
 
+        df = df.reset_index(drop=True)
         df = df.sort_values('ds')
-        df.reset_index(inplace=True, drop=True)
 
         self.initialize_scales(initialize_scales, df)
 

--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -262,8 +262,10 @@ class Prophet(object):
                     raise ValueError('Found non-boolean in column ' + condition_name)
                 df[condition_name] = df[condition_name].astype('bool')
 
-        df = df.reset_index(drop=True)
+        if df.index.name == 'ds':
+            df.index.name = None
         df = df.sort_values('ds')
+        df = df.reset_index(drop=True)
 
         self.initialize_scales(initialize_scales, df)
 

--- a/python/fbprophet/tests/test_prophet.py
+++ b/python/fbprophet/tests/test_prophet.py
@@ -102,6 +102,14 @@ class TestProphet(TestCase):
 
         self.assertTrue('y_scaled' in history)
         self.assertEqual(history['y_scaled'].max(), 1.0)
+    
+    def test_setup_dataframe_ds_column(self):
+        "Test case where 'ds' exists as an index name and column"
+        df = DATA.copy()
+        df.index = df.loc[:, 'ds']
+        m = Prophet()
+        m.fit(df)
+
 
     def test_logistic_floor(self):
         m = Prophet(growth='logistic')


### PR DESCRIPTION
Picked up issue #891 and implemented a quick fix as discussed in the issue. Also made the reset_index compatible with future pandas version as I understand that they will drop the `inplace` kwarg.