### PR TITLE
Make stan_fit accessible from outside

### DIFF
--- a/R/R/prophet.R
+++ b/R/R/prophet.R
@@ -1263,8 +1263,8 @@ fit.prophet <- function(m, df, ...) {
       iter = m$mcmc.samples
     )
     args <- utils::modifyList(args, list(...))
-    stan.fit <- do.call(rstan::sampling, args)
-    m$params <- rstan::extract(stan.fit)
+    m$stan.fit <- do.call(rstan::sampling, args)
+    m$params <- rstan::extract(m$stan.fit)
     n.iteration <- length(m$params$k)
   } else {
     args <- list(
@@ -1276,15 +1276,15 @@ fit.prophet <- function(m, df, ...) {
       as_vector = FALSE
     )
     args <- utils::modifyList(args, list(...))
-    stan.fit <- do.call(rstan::optimizing, args)
-    if (stan.fit$return_code != 0) {
+    m$stan.fit <- do.call(rstan::optimizing, args)
+    if (m$stan.fit$return_code != 0) {
       message(
         'Optimization terminated abnormally. Falling back to Newton optimizer.'
       )
       args$algorithm = 'Newton'
-      stan.fit <- do.call(rstan::optimizing, args)
+      m$stan.fit <- do.call(rstan::optimizing, args)
     }
-    m$params <- stan.fit$par
+    m$params <- m$stan.fit$par
     n.iteration <- 1
   }
   

--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -1116,9 +1116,9 @@ class Prophet(object):
                 iter=self.mcmc_samples,
             )
             args.update(kwargs)
-            stan_fit = model.sampling(**args)
-            for par in stan_fit.model_pars:
-                self.params[par] = stan_fit[par]
+            self.stan_fit = model.sampling(**args)
+            for par in self.stan_fit.model_pars:
+                self.params[par] = self.stan_fit[par]
                 # Shape vector parameters
                 if par in ['delta', 'beta'] and len(self.params[par].shape) < 2:
                     self.params[par] = self.params[par].reshape((-1, 1))

--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -1131,17 +1131,17 @@ class Prophet(object):
             )
             args.update(kwargs)
             try:
-                params = model.optimizing(**args)
+                self.stan_fit = model.optimizing(**args)
             except RuntimeError:
                 # Fall back on Newton
                 logger.warning(
                     'Optimization terminated abnormally. Falling back to Newton.'
                 )
                 args['algorithm'] = 'Newton'
-                params = model.optimizing(**args)
+                self.stan_fit = model.optimizing(**args)
 
-            for par in params:
-                self.params[par] = params[par].reshape((1, -1))
+            for par in self.stan_fit:
+                self.params[par] = self.stan_fit[par].reshape((1, -1))
 
         # If no changepoints were requested, replace delta with 0s
         if len(self.changepoints) == 0:


### PR DESCRIPTION
Currently the result of `stan_fit = model.sampling(**args)` ([link](https://github.com/facebook/prophet/blob/master/python/fbprophet/forecaster.py#L1119)) is not accessible from Prophet model object, since it is saved to a local variable. The same in R code ([link](https://github.com/facebook/prophet/blob/master/R/R/prophet.R#L1266)).

However, accessing it could be useful. For example, for [retrieving](https://github.com/stan-dev/pystan/issues/396#issuecomment-343018644) `Rhat`.

It is interesting that actually there are definitions of variables which are never used:
Python:
`self.stan_fit = None`
R:
```
# This and following attributes are set during fitting
...
stan.fit = NULL,
...
```

Seems like it's just about forgotten `self.` for Python and `m$` for R.


1. First commit fixes it by using class members instead of local variables.
2. The second commit saves the result of `model.optimizing(**args)` to `stan_fit`, in order to be consistent with the R version.

Have a nice day!