### PR TITLE
Issue #1040: Adds fit_kwargs

### DIFF
--- a/python/fbprophet/diagnostics.py
+++ b/python/fbprophet/diagnostics.py
@@ -77,7 +77,7 @@ def cross_validation(model, horizon, period=None, initial=None, fit_kwargs=None)
     initial: string with pd.Timedelta compatible style. The first training
         period will begin here. If not provided, 3 * horizon is used.
     fit_kwargs: Additional arguments passed to the optimizing or sampling functions in Stan.
-        If it is not 'None' it replaces the fit_kwargs if the model.
+        If it is not 'None' it replaces the fit_kwargs of the model.
 
     Returns
     -------
@@ -112,7 +112,7 @@ def cross_validation(model, horizon, period=None, initial=None, fit_kwargs=None)
     for cutoff in cutoffs:
         # Generate new object with copying fitting options
         m = prophet_copy(model, cutoff)
-        # Replace the fit_kwargs from the model
+        # Replace the fit_kwargs of the model
         if fit_kwargs is not None:
             m.fit_kwargs = fit_kwargs
         # Train model

--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -77,7 +77,8 @@ class Prophet(object):
     uncertainty_samples: Number of simulated draws used to estimate
         uncertainty intervals. Settings this value to 0 or False will disable
         uncertainty estimation and speed up the calculation.
-    fit_kwargs: Additional arguments passed to the optimizing or sampling functions in Stan.
+    fit_kwargs: Additional arguments passed to the optimizing or
+        sampling functions of the StanModel.
     """
 
     def __init__(
@@ -1106,14 +1107,31 @@ class Prophet(object):
             }
 
         def add_fit_kwargs(args, fit_kwargs, valid_args):
-            args.update({k: v for k, v in self.fit_kwargs.items() if k in valid_args and k not in args.keys()})
+            args.update({k: v for k, v in self.fit_kwargs.items()
+                         if k in valid_args and k not in args.keys()})
 
-        # From https://pystan.readthedocs.io/en/latest/_modules/pystan/model.html
-        optimizing_valid_args = {"iter", "save_iterations", "refresh",
-                      "init_alpha", "tol_obj", "tol_grad", "tol_param",
-                      "tol_rel_obj", "tol_rel_grad", "history_size"}
+        # From the pystan model
+        # https://pystan.readthedocs.io/en/latest/_modules/pystan/model.html
+        # Optimizing function parameters
+        optimizing_valid_args = {"seed", "sample_file", "verbose"}
 
-        sampling_valid_args = {"chain_id", "init_r", "test_grad", "append_samples", "refresh", "control"}
+        # Optimizing function additional parameters
+        optimizing_extra_args = {"iter", "save_iterations", "refresh",
+                                 "init_alpha", "tol_obj", "tol_grad",
+                                 "tol_param", "tol_rel_obj", "tol_rel_grad",
+                                 "history_size"}
+
+        optimizing_valid_args = optimizing_valid_args.union(optimizing_extra_args)
+
+        # Sampling function parameters
+        sampling_valid_args = {"chains", "warmup", "thin", "seed",
+                               "sample_file", "diagnostic_file",
+                               "verbose", "n_jobs"}
+
+        sampling_extra_args = {"chain_id", "init_r", "test_grad",
+                               "append_samples", "refresh", "control"}
+        # Sampling function additional parameters
+        sampling_valid_args = sampling_valid_args.union(sampling_extra_args)
 
         if (
                 (history['y'].min() == history['y'].max())

--- a/python/fbprophet/tests/test_prophet.py
+++ b/python/fbprophet/tests/test_prophet.py
@@ -783,3 +783,12 @@ class TestProphet(TestCase):
              'holidays',
             },
         )
+
+    def test_fit_kwargs(self):
+        df = DATA.copy()
+        fit_kwargs = {"history_size": 10}
+        m = Prophet(fit_kwargs=fit_kwargs)
+        res = m.fit(df)
+        # Check that the n_jobs parameters was used
+        print(res.params)
+        self.assertTrue(res.stan_args["history_size"] == fit_kwargs["history_size"])

--- a/python/fbprophet/tests/test_prophet.py
+++ b/python/fbprophet/tests/test_prophet.py
@@ -786,9 +786,8 @@ class TestProphet(TestCase):
 
     def test_fit_kwargs(self):
         df = DATA.copy()
-        fit_kwargs = {"history_size": 10}
-        m = Prophet(fit_kwargs=fit_kwargs)
+        fit_kwargs = {"n_jobs": 1}
+        m = Prophet(mcmc_samples=100, fit_kwargs=fit_kwargs)
         res = m.fit(df)
         # Check that the n_jobs parameters was used
-        print(res.params)
-        self.assertTrue(res.stan_args["history_size"] == fit_kwargs["history_size"])
+        self.assertTrue(res.stan_args["n_jobs"] == fit_kwargs["n_jobs"])


### PR DESCRIPTION
This pull request adds the functionality requested in #1040 by adding a `fit_kwargs` parameter to the cross_validation method and to the Prophet class. `fit_kwargs` can be used to pass additional parameters for the optimizing and sampling functions of StanModel. I checked https://pystan.readthedocs.io/en/latest/_modules/pystan/model.html to see what parameters can be used.

I am new to contributing in open source projects. I appreciate your patience and guidance in advance.

Thanks!