### PR TITLE
Update requirements.txt

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,3 +7,4 @@ LunarCalendar>=0.0.9
 convertdate>=2.1.2
 holidays>=0.9.5
 setuptools-git>=1.2
+plotly<4.0.0


### PR DESCRIPTION
Plotly 4.0 underwent a lot of breaking changes, which makes Prophet un-importable.