### PR TITLE
Attempt to solve ABI issue with build requirement for stan(and numpy/Cython??)

### DIFF
--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -2,6 +2,7 @@ include stan/unix/*.stan
 include stan/win/*.stan
 include LICENSE
 include requirements.txt
+include pyproject.toml
 
 # Ensure in-place built models do not get included in the source dist.
 prune fbprophet/stan_model

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["Cython>=0.22", "numpy>=1.10.0", "pystan>=2.14", "setuptools", "wheel"]
+

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,3 @@
-Cython>=0.22
-pystan>=2.14
-numpy>=1.10.0
 pandas>=0.23.4
 matplotlib>=2.0.0
 LunarCalendar>=0.0.9

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,6 @@
+Cython>=0.22
+pystan>=2.14
+numpy>=1.10.0
 pandas>=0.23.4
 matplotlib>=2.0.0
 LunarCalendar>=0.0.9

--- a/python/setup.py
+++ b/python/setup.py
@@ -100,6 +100,19 @@ class TestCommand(test_command):
 with open('requirements.txt', 'r') as f:
     install_requires = f.read().splitlines()
 
+try:
+    from numpy import __version__ as numpy_build_version
+    from Cython import __version__ as Cython_build_version
+    from pystan import  __version__ as pystan_build_version
+    install_requires.extend([
+        "numpy=={}".format(numpy_build_version),
+        "Cython=={}".format(Cython_build_version),
+        "pystan=={}".format(pystan_build_version),
+    ])
+except ImportError:
+    print("How could this happen???")
+    raise
+
 setup(
     name='fbprophet',
     version='0.5',


### PR DESCRIPTION
According to https://github.com/facebook/prophet/issues/401#issuecomment-452484397, it seems like the largest issue with using pyproject.toml is the ABI incompatibility issue. This ensures that the build version of pystan will match the run version.