### PR TITLE
fixed issue where plotting components with plotly was not working

### DIFF
--- a/python/fbprophet/plot.py
+++ b/python/fbprophet/plot.py
@@ -902,7 +902,7 @@ def get_forecast_component_plotly_props(m, fcst, name, uncertainty=True, plot_ca
         type='date',
         range=range_x)
     yaxis = go.layout.YAxis(rangemode='normal' if name == 'trend' else 'tozero',
-                            title=go.layout.yaxis.Title(text=name),
+                            title=name,
                             zerolinecolor=zeroline_color)
     if name in m.component_modes['multiplicative']:
         yaxis.update(tickformat='%', hoverformat='.2%')
@@ -985,7 +985,7 @@ def get_seasonality_plotly_props(m, name, uncertainty=True):
         range=[df_y['ds'].min() - range_margin, df_y['ds'].max() + range_margin]
     )
 
-    yaxis = go.layout.YAxis(title=go.layout.yaxis.Title(text=name),
+    yaxis = go.layout.YAxis(title=name,
                             zerolinecolor=zeroline_color)
     if m.seasonalities[name]['mode'] == 'multiplicative':
         yaxis.update(tickformat='%', hoverformat='.2%')


### PR DESCRIPTION
I changed only a few lines of code (904-906 & 988-989). In both instances the problematic code was:

`title=go.layout.yaxis.Title(text=name),`

Because `go.layout.yaxis` does not have a method `Title(text=name)`, I had to replace it entirely with the variable `name`. The properly functioning code reads as:

`title=name`