### PR TITLE
Fix #1189, fix plotting and add more tests

### DIFF
--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -1146,8 +1146,8 @@ class Prophet(object):
         # If no changepoints were requested, replace delta with 0s
         if len(self.changepoints) == 0:
             # Fold delta into the base rate k
-            self.params['k'] = self.params['k'] + self.params['delta']
-            self.params['delta'] = np.zeros(self.params['delta'].shape)
+            self.params['k'] = self.params['k'] + self.params['delta'].reshape(-1)
+            self.params['delta'] = np.zeros(self.params['delta'].shape).reshape((-1, 1))
 
         return self
 

--- a/python/fbprophet/plot.py
+++ b/python/fbprophet/plot.py
@@ -441,7 +441,7 @@ def add_changepoints_to_plot(
         artists.append(ax.plot(fcst['ds'], fcst['trend'], c=cp_color))
     signif_changepoints = m.changepoints[
         np.abs(np.nanmean(m.params['delta'], axis=0)) >= threshold
-    ]
+    ] if len(m.changepoints) > 0 else []
     for cp in signif_changepoints:
         artists.append(ax.axvline(x=cp, c=cp_color, ls=cp_linestyle))
     return artists
@@ -628,7 +628,7 @@ def plot_plotly(m, fcst, uncertainty=True, plot_cap=True, trend=False, changepoi
             line=dict(color=trend_color, width=line_width),
         ))
     # Add changepoints
-    if changepoints:
+    if changepoints and len(m.changepoints) > 0:
         signif_changepoints = m.changepoints[
             np.abs(np.nanmean(m.params['delta'], axis=0)) >= changepoints_threshold
         ]

--- a/python/fbprophet/tests/test_prophet.py
+++ b/python/fbprophet/tests/test_prophet.py
@@ -55,6 +55,10 @@ class TestProphet(TestCase):
         forecaster.fit(train)
         forecaster.predict(future)
 
+        forecaster = Prophet(n_changepoints=0, mcmc_samples=100)
+        forecaster.fit(train)
+        forecaster.predict(future)
+
     def test_fit_changepoint_not_in_history(self):
         train = DATA[(DATA['ds'] < '2013-01-01') | (DATA['ds'] > '2014-01-01')]
         future = pd.DataFrame({'ds': DATA['ds']})


### PR DESCRIPTION
I repeated MCMC sampling with n_changepoints=0 as it had been described in #1189. I also used `mcmc_samples=100`.

**Observed behavior:**

`predict()` failed with an error:
```
/usr/local/lib/python3.6/dist-packages/fbprophet/forecaster.py in piecewise_linear(t, deltas, k, m, changepoint_ts)
   1209         gammas = -changepoint_ts * deltas
   1210         # Get cumulative slope and intercept at each t
-> 1211         k_t = k * np.ones_like(t)
   1212         m_t = m * np.ones_like(t)
   1213         for s, t_s in enumerate(changepoint_ts):

ValueError: operands could not be broadcast together with shapes (200,) (1584,) 
```
After the fitting the shape of `k` was `(200, 200)` while it should've been `(200, )`. `piecewise_linear()` expected `k` to be an integer, but got a 1D subarray.
The wrong shape was obtained at the following line:
```
self.params['k'] = self.params['k'] + self.params['delta']
```
During summation the shape of `delta`should've been `(200,)`, and `(200, 1)` afterwards.

This code worked for MAP estimation since `k` and `delta` were just 1x1 arrays in this case.

Tested with fbprophet 0.3 and 0.5, Python 2.7.x