### PR TITLE
add a little code for make sure last_day is format of datetime with unit is day

### DIFF
--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -1494,7 +1494,7 @@ class Prophet(object):
         """
         if self.history_dates is None:
             raise Exception('Model must be fit before this can be used.')
-        last_date = self.history_dates.max()
+        last_date = pd.to_datetime(self.history_dates.max(), unit='D')
         dates = pd.date_range(
             start=last_date,
             periods=periods + 1,  # An extra in case we include start


### PR DESCRIPTION
When i use prophet in superset source code for predicting from csv file. The format of datetime of csv file is change from YY-MM-DD to YY-MM-DD HH-MM-SS. So i think the code :

> last_date = self.history_dates.max()

 is so vulnerable.
I change the code and with new code is make sure that the last_date is always get true format for 
"pd.date_range" function. 