### PR TITLE
Modified text in saturating_forecasts.md

### DIFF
--- a/docs/_docs/saturating_forecasts.md
+++ b/docs/_docs/saturating_forecasts.md
@@ -57,7 +57,7 @@ m <- prophet(df, growth = 'logistic')
 m = Prophet(growth='logistic')
 m.fit(df)
 ```
-We make a dataframe for future predictions as before, except we must also specify the capacity in the future. Here we keep capacity constant at the same value as in the history, and forecast 3 years into the future:
+We make a dataframe for future predictions as before, except we must also specify the capacity in the future. Here we keep capacity constant at the same value as in the history, and forecast 5 years into the future:
 
 
 ```R


### PR DESCRIPTION
Changed forecast period on line 60 from '3' years to '5' years. 5 years is actually what is being calculated in the example.