### PR TITLE
fix output of valid metrics in performance_metrics

### DIFF
--- a/R/R/diagnostics.R
+++ b/R/R/diagnostics.R
@@ -249,7 +249,7 @@ performance_metrics <- function(df, metrics = NULL, rolling_window = 0.1) {
   }
   if (!all(metrics %in% valid_metrics)) {
     stop(
-      paste('Valid values for metrics are:', paste(metrics, collapse = ", "))
+      paste('Valid values for metrics are:', paste(valid_metrics, collapse = ", "))
     )
   }
   df_m <- df

--- a/R/tests/testthat/test_diagnostics.R
+++ b/R/tests/testthat/test_diagnostics.R
@@ -129,6 +129,11 @@ test_that("performance_metrics", {
   ))
   df_horizon <- performance_metrics(df_cv, metrics = c('mape'))
   expect_null(df_horizon)
+  # List of metrics containing non valid metrics
+  expect_error(
+     performance_metrics(df, metrics = c('mse', 'error_metric')),
+     'Valid values for metrics are: mse, rmse, mae, mape, coverage'
+  )
 })
 
 test_that("rolling_mean", {


### PR DESCRIPTION
If the user inputs metrics which are not valid, he gets to see his **own input** metrics, however I guess its intended for the user to see **real valid metrics**.