### PR TITLE
add missing pystan setup dependency

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -110,6 +110,7 @@ setup(
     license='MIT',
     packages=find_packages(),
     setup_requires=[
+        'pystan>=2.14',
     ],
     install_requires=install_requires,
     zip_safe=False,


### PR DESCRIPTION
During setup, build_stan_model() requires pystan. Build tools that
enforce strict dependency trees fail to install fbprophet. This change
makes the implicit dependency explicit.