### PR TITLE
Redirecting dead link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ After installation, you can [get started!](https://facebook.github.io/prophet/do
 
 ### Windows
 
-On Windows, R requires a compiler so you'll need to [follow the instructions](https://github.com/stan-dev/rstan/wiki/Installing-RStan-on-Windows) provided by `rstan`. The key step is installing [Rtools](http://cran.r-project.org/bin/windows/Rtools/) before attempting to install the package.
+On Windows, R requires a compiler so you'll need to [follow the instructions](https://github.com/stan-dev/rstan/wiki/RStan-Getting-Started) provided by `rstan`. The key step is installing [Rtools](http://cran.r-project.org/bin/windows/Rtools/) before attempting to install the package.
 
 If you have custom Stan compiler settings, install from source rather than the CRAN binary.
 


### PR DESCRIPTION
There's a link in the **Installation in R** section of README.md that links to a page in the RStan Wiki that no longer exists - I've redirected the link to the most appropriate alternative page.