### PR TITLE
do not import holidays==0.10.1 due to refactoring

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,5 +5,5 @@ pandas>=0.23.4
 matplotlib>=2.0.0
 LunarCalendar>=0.0.9
 convertdate>=2.1.2
-holidays>=0.9.5
+holidays>=0.9.5,<0.10.1
 setuptools-git>=1.2


### PR DESCRIPTION
This is a temporary solution for the version change of the holidays package.