### PR TITLE
Make sure to cleanup files of previous model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
 script:
   - cd python && python setup.py develop test
   - python setup.py clean
+  - rm -rf fbprophet/stan_model
   - wget https://github.com/stan-dev/cmdstan/releases/download/v2.22.1/cmdstan-2.22.1.tar.gz -O /tmp/cmdstan.tar.gz > /dev/null
   - tar -xvf /tmp/cmdstan.tar.gz -C /tmp > /dev/null
   - make -C /tmp/cmdstan-2.22.1/ build > /dev/null


### PR DESCRIPTION
I've noticed that `python setup.py clean` doesn't clean generated models, and we want to be sure that the `CMDSTANPY` backend really uses cmdstan and does not fallback to pystan in our tests.