### PR TITLE
Remove logging.root basicConfig on fbprophet import

### DIFF
--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -19,9 +19,7 @@ from fbprophet.models import StanBackendEnum
 from fbprophet.plot import (plot, plot_components)
 
 logger = logging.getLogger('fbprophet')
-logger.addHandler(logging.NullHandler())
-if len(logger.handlers) == 1:
-    logging.basicConfig(level=logging.INFO)
+logger.setLevel(logging.INFO)
 
 
 class Prophet(object):


### PR DESCRIPTION
This PR fixes #1006 . Like the people there, we are struggling with logging configuration and duplicate log messages, because in our ML pipeline we import and use `fbprophet`, and `import fbprophet` does mess with the root logger, and causes duplicate logging messages, and also means that if we call `logging.basicConfig` after `import fbprophet`, it has no effect any more, which is very confusing to new users.

This PR changes the logging to follow the standard recommendation for Python libraries (see [here](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library)).  Note that since Python 3.2, there is [logging.lastResort](https://docs.python.org/3/library/logging.html#logging.lastResort) in place, a handler of last resort, which I think to a large degree removes the motivation libraries had in Python 2 to add a handler so that library users will see logging messages by default - this is now the case anyways.

I'll have a look at PyStan now - probably will make the same change request there.

@bletham - Could you please try with this logging setup, and see if behaviour is acceptable for the use cases you have in mind? If no, what exactly is the issue? - Would like to try and resolve it without using the root logger, just the fbprophet logger.