### PR TITLE
Add possibility of selecting province of country for creation of holiday dataframe

### DIFF
--- a/python/fbprophet/make_holidays.py
+++ b/python/fbprophet/make_holidays.py
@@ -40,7 +40,7 @@ def get_holiday_names(country):
     return set(holiday_names)
 
 
-def make_holidays_df(year_list, country):
+def make_holidays_df(year_list, country, province=None):
     """Make dataframe of holidays for given years and countries
 
     Parameters
@@ -57,7 +57,7 @@ def make_holidays_df(year_list, country):
         holidays = getattr(hdays_part2, country)(years=year_list)
     except AttributeError:
         try:
-            holidays = getattr(hdays_part1, country)(years=year_list)
+            holidays = getattr(hdays_part1, country)(prov=province,years=year_list)
         except AttributeError:
             raise AttributeError(
                 "Holidays in {} are not currently supported!".format(country))


### PR DESCRIPTION
This PR adds the possibility of selecting a province of a given country for the creation of a holiday dataframe from the python-holidays-package using make_holidays.py.
Example:
```
from fbprophet.make_holidays import make_holidays_df

year_list = [2016, 2017, 2018, 2019, 2020]
holidays = make_holidays_df(year_list=year_list, country='DE', province="NW")
```