### PR TITLE
sampling iters arg name, logic changes

### DIFF
--- a/python/fbprophet/models.py
+++ b/python/fbprophet/models.py
@@ -57,7 +57,7 @@ class CmdStanPyBackend(IStanBackend):
         model_name = 'prophet.stan'
         target_name = 'prophet_model.bin'
 
-        sm = cmdstanpy.Model(stan_file=os.path.join(model_dir, model_name))
+        sm = cmdstanpy.CmdStanModel(stan_file=os.path.join(model_dir, model_name))
         sm.compile()
         copy(sm.exe_file, os.path.join(target_dir, target_name))
 
@@ -67,7 +67,7 @@ class CmdStanPyBackend(IStanBackend):
             'fbprophet',
             'stan_model/prophet_model.bin',
         )
-        return cmdstanpy.Model(exe_file=model_file)
+        return cmdstanpy.CmdStanModel(exe_file=model_file)
 
     def fit(self, stan_init, stan_data, **kwargs):
         (stan_init, stan_data) = self.prepare_data(stan_init, stan_data)

--- a/python/fbprophet/models.py
+++ b/python/fbprophet/models.py
@@ -103,12 +103,13 @@ class CmdStanPyBackend(IStanBackend):
 
         if 'chains' not in kwargs:
             kwargs['chains'] = 4
-        if 'warmup_iters' not in kwargs:
-            kwargs['warmup_iters'] = samples // 2
+        iter_half = samples // 2
+        if 'iter_warmup' not in kwargs:
+            kwargs['iter_warmup'] = iter_half
 
         self.stan_fit = self.model.sample(data=stan_data,
                                      inits=stan_init,
-                                     sampling_iters=samples,
+                                     iter_sampling=iter_half,
                                      **kwargs)
         res = self.stan_fit.sample
         (samples, c, columns) = res.shape

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 Cython>=0.22
-cmdstanpy==0.4
+cmdstanpy==0.9.5
 pystan>=2.14
 numpy>=1.10.0
 pandas>=0.23.4


### PR DESCRIPTION
Changed call to CmdStanPy `sample` method fo CmdStanPy backend to match new argument names, per issue https://github.com/facebook/prophet/issues/1388

Also changed number of sampling iterations - in CmdStan, unlike PyStan and RStan, you specify the number of warmup and sampling iterations as args `num_warmup` and `num_samples`, respectively.  In PyStan and RStan, argument `iter` is the total number of iterations.
It looks like as currently written, the CmdStanPy backend will run twice as many sampling iters as intended.
