### PR TITLE
modified cross_validation to allow custom cutoffs

### DIFF
--- a/python/fbprophet/diagnostics.py
+++ b/python/fbprophet/diagnostics.py
@@ -119,7 +119,6 @@ def cross_validation(model, horizon, period=None, initial=None, multiprocess=Fal
         # Compute Cutoffs
         cutoffs = generate_cutoffs(df, horizon, initial, period)
 
-        
 
     if multiprocess is True:
         with Pool() as pool:

--- a/python/fbprophet/diagnostics.py
+++ b/python/fbprophet/diagnostics.py
@@ -113,15 +113,19 @@ def cross_validation(model, horizon, period=None, initial=None, multiprocess=Fal
             initial = max(3 * horizon, seasonality_dt)
         else:
             initial = pd.Timedelta(initial)
-        if initial < seasonality_dt:
-            msg = 'Seasonality has period of {} days '.format(period_max)
-            msg += 'which is larger than initial window. '
-            msg += 'Consider increasing initial.'
-            logger.warning(msg)
         # Compute Cutoffs
         cutoffs = generate_cutoffs(df, horizon, initial, period)
     else:
         initial = cutoffs[0] - df['ds'].min()
+        
+    # Check if the initial window 
+    # (that is, the amount of time between the start of the history and the first cutoff)
+    # is less than the maximum seasonality period
+    if initial < seasonality_dt:
+            msg = 'Seasonality has period of {} days '.format(period_max)
+            msg += 'which is larger than initial window. '
+            msg += 'Consider increasing initial.'
+            logger.warning(msg)
 
     if multiprocess is True:
         with Pool() as pool:

--- a/python/fbprophet/diagnostics.py
+++ b/python/fbprophet/diagnostics.py
@@ -59,12 +59,12 @@ def generate_cutoffs(df, horizon, initial, period):
     return list(reversed(result))
 
 
-def cross_validation(model, horizon, period=None, initial=None, multiprocess=False):
+def cross_validation(model, horizon, period=None, initial=None, multiprocess=False, cutoffs=None):
     """Cross-Validation for time series.
 
-    Computes forecasts from historical cutoff points. Beginning from
-    (end - horizon), works backwards making cutoffs with a spacing of period
-    until initial is reached.
+    Computes forecasts from historical cutoff points, which user can input.
+    If not provided beginning from (end - horizon), works backwards making 
+    cutoffs with a spacing of period until initial is reached.
 
     When period is equal to the time interval of the data, this is the
     technique described in https://robjhyndman.com/hyndsight/tscv/ .
@@ -78,6 +78,10 @@ def cross_validation(model, horizon, period=None, initial=None, multiprocess=Fal
         be done at every this period. If not provided, 0.5 * horizon is used.
     initial: string with pd.Timedelta compatible style. The first training
         period will begin here. If not provided, 3 * horizon is used.
+    cutoffs: list of pd.Timestamp representing cutoff to be used during
+        cross-validtation. If not provided works beginning from
+        (end - horizon), works backwards making cutoffs with a spacing of period
+        until initial is reached.
     multiprocess: True, False, Optional (defaults to False). If `True`, use the
         `multiprocessing` module to distribute each task to a different processor
         core.
@@ -111,7 +115,8 @@ def cross_validation(model, horizon, period=None, initial=None, multiprocess=Fal
     if model.uncertainty_samples:
         predict_columns.extend(['yhat_lower', 'yhat_upper'])
 
-    cutoffs = generate_cutoffs(df, horizon, initial, period)
+    if cutoffs is None:
+        cutoffs = generate_cutoffs(df, horizon, initial, period)
 
     if multiprocess is True:
         with Pool() as pool:

--- a/python/fbprophet/tests/test_diagnostics.py
+++ b/python/fbprophet/tests/test_diagnostics.py
@@ -141,9 +141,8 @@ class TestDiagnostics(TestCase):
             horizon='32 days',
             period='10 days',
             cutoffs=[pd.Timestamp('2012-07-31'), pd.Timestamp('2012-08-31')])
-        self.assertItemsEqual(
-            (df_cv1['cutoff'].unique(), [pd.Timestamp('2012-07-31'), pd.Timestamp('2012-08-31')]))  
-        
+        self.assertEqual(len(df_cv1['cutoff'].unique()), 2)
+      
     def test_cross_validation_uncertainty_disabled(self):
         df = self.__df.copy()
         for uncertainty in [0, False]:

--- a/python/fbprophet/tests/test_diagnostics.py
+++ b/python/fbprophet/tests/test_diagnostics.py
@@ -10,8 +10,6 @@ from __future__ import unicode_literals
 
 import itertools
 import os
-# new line added
-import unittest
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -123,6 +121,19 @@ class TestDiagnostics(TestCase):
     def test_cross_validation_default_value_check(self):
         m = Prophet()
         m.fit(self.__df)
+        # Default value of initial should be equal to 3 * horizon
+        df_cv1 = diagnostics.cross_validation(
+            m, horizon='32 days', period='10 days')
+        df_cv2 = diagnostics.cross_validation(
+            m, horizon='32 days', period='10 days', initial='96 days')
+        self.assertAlmostEqual(
+            ((df_cv1['y'] - df_cv2['y']) ** 2).sum(), 0.0)
+        self.assertAlmostEqual(
+            ((df_cv1['yhat'] - df_cv2['yhat']) ** 2).sum(), 0.0)
+
+    def test_cross_validation_custom_cutoffs(self):
+        m = Prophet()
+        m.fit(self.__df)
         # When specify a list of cutoffs
         #  the cutoff dates in df_cv are those specified
         df_cv1 = diagnostics.cross_validation(
@@ -131,17 +142,8 @@ class TestDiagnostics(TestCase):
             period='10 days',
             cutoffs=[pd.Timestamp('2012-07-31'), pd.Timestamp('2012-08-31')])
         self.assertCountEqual(
-            (df_cv1['cutoff'].unique(), [pd.Timestamp('2012-07-31'), pd.Timestamp('2012-08-31')]))
-        # Default value of initial should be equal to 3 * horizon
-        df_cv2 = diagnostics.cross_validation(
-            m, horizon='32 days', period='10 days')
-        df_cv3 = diagnostics.cross_validation(
-            m, horizon='32 days', period='10 days', initial='96 days')
-        self.assertAlmostEqual(
-            ((df_cv2['y'] - df_cv3['y']) ** 2).sum(), 0.0)
-        self.assertAlmostEqual(
-            ((df_cv2['yhat'] - df_cv3['yhat']) ** 2).sum(), 0.0)
-
+            (df_cv1['cutoff'].unique(), [pd.Timestamp('2012-07-31'), pd.Timestamp('2012-08-31')]))  
+        
     def test_cross_validation_uncertainty_disabled(self):
         df = self.__df.copy()
         for uncertainty in [0, False]:
@@ -325,6 +327,3 @@ class TestDiagnostics(TestCase):
         self.assertTrue('custom' in m2.seasonalities)
         self.assertTrue('binary_feature' in m2.extra_regressors)
 
-# new lines added
-if __name__ == "__main__":
-    unittest.main()

--- a/python/fbprophet/tests/test_diagnostics.py
+++ b/python/fbprophet/tests/test_diagnostics.py
@@ -141,7 +141,7 @@ class TestDiagnostics(TestCase):
             horizon='32 days',
             period='10 days',
             cutoffs=[pd.Timestamp('2012-07-31'), pd.Timestamp('2012-08-31')])
-        self.assertCountEqual(
+        self.assertItemsEqual(
             (df_cv1['cutoff'].unique(), [pd.Timestamp('2012-07-31'), pd.Timestamp('2012-08-31')]))  
         
     def test_cross_validation_uncertainty_disabled(self):

--- a/python/fbprophet/tests/test_diagnostics.py
+++ b/python/fbprophet/tests/test_diagnostics.py
@@ -10,6 +10,8 @@ from __future__ import unicode_literals
 
 import itertools
 import os
+# new line added
+import unittest
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -121,15 +123,24 @@ class TestDiagnostics(TestCase):
     def test_cross_validation_default_value_check(self):
         m = Prophet()
         m.fit(self.__df)
-        # Default value of initial should be equal to 3 * horizon
+        # When specify a list of cutoffs
+        #  the cutoff dates in df_cv are those specified
         df_cv1 = diagnostics.cross_validation(
-            m, horizon='32 days', period='10 days')
+            m,
+            horizon='32 days',
+            period='10 days',
+            cutoffs=[pd.Timestamp('2012-07-31'), pd.Timestamp('2012-08-31')])
+        self.assertCountEqual(
+            (df_cv1['cutoff'].unique(), [pd.Timestamp('2012-07-31'), pd.Timestamp('2012-08-31')]))
+        # Default value of initial should be equal to 3 * horizon
         df_cv2 = diagnostics.cross_validation(
+            m, horizon='32 days', period='10 days')
+        df_cv3 = diagnostics.cross_validation(
             m, horizon='32 days', period='10 days', initial='96 days')
         self.assertAlmostEqual(
-            ((df_cv1['y'] - df_cv2['y']) ** 2).sum(), 0.0)
+            ((df_cv2['y'] - df_cv3['y']) ** 2).sum(), 0.0)
         self.assertAlmostEqual(
-            ((df_cv1['yhat'] - df_cv2['yhat']) ** 2).sum(), 0.0)
+            ((df_cv2['yhat'] - df_cv3['yhat']) ** 2).sum(), 0.0)
 
     def test_cross_validation_uncertainty_disabled(self):
         df = self.__df.copy()
@@ -313,3 +324,7 @@ class TestDiagnostics(TestCase):
         self.assertTrue((changepoints == m2.changepoints).all())
         self.assertTrue('custom' in m2.seasonalities)
         self.assertTrue('binary_feature' in m2.extra_regressors)
+
+# new lines added
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Modified the cross_validation function in diagnostics.py in order to allow users to pass custom cutoff dates to be used instead of auto-generated ones.

A new parameter called cutffs has been added of type: list of pd.Timestamp.