### PR TITLE
Limit holidays version to 0.9.12

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,7 +6,7 @@ pandas>=0.23.4
 matplotlib>=2.0.0
 LunarCalendar>=0.0.9
 convertdate>=2.1.2
-holidays>=0.9.5
+holidays>=0.9.5,<=0.9.12
 setuptools-git>=1.2
 python-dateutil>=2.8.0
 tqdm>=4.36.1


### PR DESCRIPTION
As per #1300, Python prophet breaks with `holidays` version >=0.10.0. The proposed workaround is to manually downgrade the dependency. Ideally we would however set dependencies such that the install works out-of-the-box.

This PR simply limits the `holidays` dependency version to do just that.

Why not do this: maybe just migrate fbprophet to work with 0.10.x of holidays?