### PR TITLE
Parallel Cross Validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 install:
   - pip install --upgrade pip
-  - pip install -U -r python/requirements.txt
+  - pip install -U -r python/requirements.txt dask dask[dataframe]
 
 script:
   - cd python && python setup.py develop test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 install:
   - pip install --upgrade pip
-  - pip install -U -r python/requirements.txt dask dask[dataframe]
+  - pip install -U -r python/requirements.txt dask[dataframe] distributed
 
 script:
   - cd python && python setup.py develop test

--- a/notebooks/diagnostics.ipynb
+++ b/notebooks/diagnostics.ipynb
@@ -263,7 +263,22 @@
    "source": [
     "In R, the argument `units` must be a type accepted by `as.difftime`, which is weeks or shorter. In Python, the string for `initial`, `period`, and `horizon` should be in the format used by Pandas Timedelta, which accepts units of days or shorter.\n",
     "\n",
-    "Cross-validation can also be run in multiprocessing mode in Python, by setting the `multiprocess` argument to `True`\n",
+    "Cross-validation can also be run in parallel mode in Python, by setting specifying the `parallel` keyword. Three modes are supported\n",
+    "\n",
+    "* `parallel=\"processes\"`\n",
+    "* `parallel=\"threads\"`\n",
+    "* `parallel=\"dask\"`\n",
+    "\n",
+    "For problems that aren't too big, we recommend using `parallel=\"processes\"`. It will achieve the highest performance when the parallel cross validation can be done on a single machine. For large problems, a [Dask](https://dask.org) cluster can be used to do the cross validation on many machines.\n",
+    "\n",
+    "\n",
+    "```python\n",
+    "from dask.distributed import Client\n",
+    "\n",
+    "client = Client()  # connect to the cluster\n",
+    "df_cv = cross_validation(m, initial='730 days', period='180 days', horizon='365 days',\n",
+    "                         parallel=\"dask\")\n",
+    "```\n",
     "\n",
     "The `performance_metrics` utility can be used to compute some useful statistics of the prediction performance (`yhat`, `yhat_lower`, and `yhat_upper` compared to `y`), as a function of the distance from the cutoff (how far into the future the prediction was). The statistics computed are mean squared error (MSE), root mean squared error (RMSE), mean absolute error (MAE), mean absolute percent error (MAPE), and coverage of the `yhat_lower` and `yhat_upper` estimates. These are computed on a rolling window of the predictions in `df_cv` after sorting by horizon (`ds` minus `cutoff`). By default 10% of the predictions will be included in each window, but this can be changed with the `rolling_window` argument."
    ]
@@ -475,7 +490,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/diagnostics.ipynb
+++ b/notebooks/diagnostics.ipynb
@@ -269,7 +269,7 @@
     "* `parallel=\"threads\"`\n",
     "* `parallel=\"dask\"`\n",
     "\n",
-    "For problems that aren't too big, we recommend using `parallel=\"processes\"`. It will achieve the highest performance when the parallel cross validation can be done on a single machine. For large problems, a [Dask](https://dask.org) cluster can be used to do the cross validation on many machines.\n",
+    "For problems that aren't too big, we recommend using `parallel=\"processes\"`. It will achieve the highest performance when the parallel cross validation can be done on a single machine. For large problems, a [Dask](https://dask.org) cluster can be used to do the cross validation on many machines. You will need to [install Dask](https://docs.dask.org/en/latest/install.html) separately, as it will not be installed with `fbprophet`.\n",
     "\n",
     "\n",
     "```python\n",

--- a/python/fbprophet/diagnostics.py
+++ b/python/fbprophet/diagnostics.py
@@ -176,8 +176,11 @@ def cross_validation(model, horizon, period=None, initial=None, parallel=None, c
             raise ValueError(msg)
 
         iterables = [
-            (df, model, cutoff, horizon, predict_columns)
-            for cutoff in cutoffs
+            itertools.cycle([df]),
+            itertools.cycle([model]),
+            cutoffs,
+            itertools.cycle([horizon]),
+            itertools.cycle([predict_columns]),
         ]
 
         logger.info("Applying in parallel with %s", pool)

--- a/python/fbprophet/diagnostics.py
+++ b/python/fbprophet/diagnostics.py
@@ -162,9 +162,9 @@ def cross_validation(model, horizon, period=None, initial=None, parallel=None, c
         elif parallel == "dask":
             try:
                 from dask.distributed import get_client
-            except ImportError:
+            except ImportError as e:
                 raise ImportError("parallel='dask' requies the optional "
-                                  "dependency dask.")
+                                  "dependency dask.") as e
             pool = get_client()
             # delay df and model to avoid large objects in task graph.
             df, model = pool.scatter([df, model])
@@ -175,13 +175,10 @@ def cross_validation(model, horizon, period=None, initial=None, parallel=None, c
                    "'map' method".format(', '.join(valid)))
             raise ValueError(msg)
 
-        iterables = [
-            itertools.cycle([df]),
-            itertools.cycle([model]),
-            cutoffs,
-            itertools.cycle([horizon]),
-            itertools.cycle([predict_columns]),
-        ]
+        iterables = (
+            (df, model, cutoff, horizon, predict_columns)
+            for cutoff in cutoffs
+        )
 
         logger.info("Applying in parallel with %s", pool)
         predicts = pool.map(single_cutoff_forecast, *iterables)

--- a/python/fbprophet/diagnostics.py
+++ b/python/fbprophet/diagnostics.py
@@ -83,7 +83,7 @@ def cross_validation(model, horizon, period=None, initial=None, parallel=None, c
         cross-validtation. If not provided works beginning from
         (end - horizon), works backwards making cutoffs with a spacing of period
         until initial is reached.
-    parallel : {None, 'processes', 'threads'}
+    parallel : {None, 'processes', 'threads', 'dask'}
 
         How to parallelize the forecast computation. By default no parallelism
         is used.

--- a/python/fbprophet/diagnostics.py
+++ b/python/fbprophet/diagnostics.py
@@ -164,7 +164,7 @@ def cross_validation(model, horizon, period=None, initial=None, parallel=None, c
                 from dask.distributed import get_client
             except ImportError as e:
                 raise ImportError("parallel='dask' requies the optional "
-                                  "dependency dask.") as e
+                                  "dependency dask.") from e
             pool = get_client()
             # delay df and model to avoid large objects in task graph.
             df, model = pool.scatter([df, model])
@@ -175,10 +175,10 @@ def cross_validation(model, horizon, period=None, initial=None, parallel=None, c
                    "'map' method".format(', '.join(valid)))
             raise ValueError(msg)
 
-        iterables = (
+        iterables = [
             (df, model, cutoff, horizon, predict_columns)
             for cutoff in cutoffs
-        )
+        ]
 
         logger.info("Applying in parallel with %s", pool)
         predicts = pool.map(single_cutoff_forecast, *iterables)

--- a/python/fbprophet/diagnostics.py
+++ b/python/fbprophet/diagnostics.py
@@ -9,9 +9,7 @@ from __future__ import absolute_import, division, print_function
 import logging
 from tqdm.autonotebook import tqdm
 from copy import deepcopy
-from functools import reduce
 import concurrent.futures
-import itertools
 
 import numpy as np
 import pandas as pd
@@ -175,13 +173,9 @@ def cross_validation(model, horizon, period=None, initial=None, parallel=None, c
                    "'map' method".format(', '.join(valid)))
             raise ValueError(msg)
 
-        iterables = [
-            itertools.cycle([df]),
-            itertools.cycle([model]),
-            cutoffs,
-            itertools.cycle([horizon]),
-            itertools.cycle([predict_columns]),
-        ]
+        iterables = ((df, model, cutoff, horizon, predict_columns)
+                     for cutoff in cutoffs)
+        iterables = zip(*iterables)
 
         logger.info("Applying in parallel with %s", pool)
         predicts = pool.map(single_cutoff_forecast, *iterables)

--- a/python/fbprophet/tests/test_diagnostics.py
+++ b/python/fbprophet/tests/test_diagnostics.py
@@ -44,7 +44,7 @@ class TestDiagnostics(TestCase):
 
         try:
             from dask.distributed import Client
-            client = Client()
+            client = Client(processes=False)  # noqa
             methods.append("dask")
         except ImportError:
             pass

--- a/python/fbprophet/tests/test_diagnostics.py
+++ b/python/fbprophet/tests/test_diagnostics.py
@@ -40,7 +40,15 @@ class TestDiagnostics(TestCase):
         horizon = pd.Timedelta('4 days')
         period = pd.Timedelta('10 days')
         initial = pd.Timedelta('115 days')
-        for parallel in [None, 'processes', 'threads']:
+        methods = [None, 'processes', 'threads']
+
+        try:
+            import dask
+            methods.append("dask")
+        except ImportError:
+            pass
+
+        for parallel in methods:
             df_cv = diagnostics.cross_validation(
                 m, horizon='4 days', period='10 days', initial='115 days',
                 parallel=parallel)

--- a/python/fbprophet/tests/test_diagnostics.py
+++ b/python/fbprophet/tests/test_diagnostics.py
@@ -71,6 +71,10 @@ class TestDiagnostics(TestCase):
                 diagnostics.cross_validation(
                     m, horizon='10 days', period='10 days', initial='140 days')
 
+        # invalid raises
+        with self.assertRaises(ValueError):
+            diagnostics.cross_validation(m, horizon="4 days", parallel="bad")
+
     def test_check_single_cutoff_forecast_func_calls(self):
         m = Prophet()
         m.fit(self.__df)

--- a/python/fbprophet/tests/test_diagnostics.py
+++ b/python/fbprophet/tests/test_diagnostics.py
@@ -40,11 +40,10 @@ class TestDiagnostics(TestCase):
         horizon = pd.Timedelta('4 days')
         period = pd.Timedelta('10 days')
         initial = pd.Timedelta('115 days')
-        # Run for both cases of multiprocess on or off
-        for multiprocess in [False, True]:
+        for parallel in [None, 'processes', 'threads']:
             df_cv = diagnostics.cross_validation(
                 m, horizon='4 days', period='10 days', initial='115 days',
-                multiprocess=multiprocess)
+                parallel=parallel)
             self.assertEqual(len(np.unique(df_cv['cutoff'])), 3)
             self.assertEqual(max(df_cv['ds'] - df_cv['cutoff']), horizon)
             self.assertTrue(min(df_cv['cutoff']) >= min(self.__df['ds']) + initial)

--- a/python/fbprophet/tests/test_diagnostics.py
+++ b/python/fbprophet/tests/test_diagnostics.py
@@ -43,7 +43,8 @@ class TestDiagnostics(TestCase):
         methods = [None, 'processes', 'threads']
 
         try:
-            import dask
+            from dask.distributed import Client
+            client = Client()
             methods.append("dask")
         except ImportError:
             pass


### PR DESCRIPTION
This changes how parallel cross validation works. It's an alternative to https://github.com/facebook/prophet/pull/1356. I think that a release hasn't been made with #1356, so hopefully this isn't breaking an existing API.

My primary motivation is to allow distributing the work on a cluster with Dask. As a precursor, https://github.com/facebook/prophet/commit/ed3639cfa204728486629f71b1c7ae025bf2c387 refactors things to use `concurrent.futures` for either thread- or process-based parallelism. Users choose parallelism with `parallel=None / "processes" / "threads"`.

https://github.com/facebook/prophet/commit/ed3639cfa204728486629f71b1c7ae025bf2c387 adds in Dask support. It provides a similar API to `concurrent.futures`, with a couple differences I'll annotate inline.

cc @ryankarlos (from #1356) if you have thoughts and @bletham.

---

Some rough timings

```
# parallel=None
CPU times: user 3min 17s, sys: 33.5 s, total: 3min 51s
Wall time: 43.1 s

parallel="threads"
CPU times: user 1min 5s, sys: 3min 27s, total: 4min 33s
Wall time: 45.4 s

# parallel="processes"
CPU times: user 1.18 s, sys: 318 ms, total: 1.49 s
Wall time: 12.2 s

# parallel="dask"
CPU times: user 954 ms, sys: 159 ms, total: 1.11 s
Wall time: 13.3 s
```