### PR TITLE
Use system.file() to obtain package installation path

### DIFF
--- a/R/R/prophet.R
+++ b/R/R/prophet.R
@@ -249,9 +249,9 @@ compile_stan_model <- function() {
   )
 
   if (.Platform$OS.type == "windows") {
-    dest <- file.path(path.package("prophet"), 'libs', .Platform$r_arch)
+    dest <- file.path(system.file(package="prophet"), 'libs', .Platform$r_arch)
   } else {
-    dest <- file.path(path.package("prophet"), 'libs')
+    dest <- file.path(system.file(package="prophet"), 'libs')
   }  
   dir.create(dest, recursive = TRUE, showWarnings = FALSE)
 


### PR DESCRIPTION
Using `path.package()` requires the package to be attached onto the search path, which is not guaranteed in other packages that import prophet (like `fable.prophet`).

Resolves https://github.com/mitchelloharawild/fable.prophet/issues/21

``` r
path.package("prophet")
#> Error in path.package("prophet"): none of the packages are loaded
system.file(package = "prophet")
#> [1] "/home/mitchell/R/x86_64-pc-linux-gnu-library/3.6/prophet"
library(prophet)
#> Warning: package 'prophet' was built under R version 3.6.3
#> Loading required package: Rcpp
#> Loading required package: rlang
path.package("prophet")
#> [1] "/home/mitchell/R/x86_64-pc-linux-gnu-library/3.6/prophet"
system.file(package = "prophet")
#> [1] "/home/mitchell/R/x86_64-pc-linux-gnu-library/3.6/prophet"
```

<sup>Created on 2020-04-16 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>