### PR TITLE
Fix Issue with Pickling Models in Python3.6 because of Logger Attribute

### DIFF
--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -150,7 +150,7 @@ class Prophet(object):
                 except Exception as e:
                     logger.debug("Unable to load backend %s (%s), trying the next one", i.name, e)
         else:
-            self.stan_backend = StanBackendEnum.get_backend_class(stan_backend)(logger)
+            self.stan_backend = StanBackendEnum.get_backend_class(stan_backend)()
 
         logger.debug("Loaded stan backend: %s", self.stan_backend.get_type())
 

--- a/python/fbprophet/models.py
+++ b/python/fbprophet/models.py
@@ -11,14 +11,15 @@ from collections import OrderedDict
 from enum import Enum
 import pickle
 import pkg_resources
-
 import os
+import logging
+
+logger = logging.getLogger('fbprophet.models')
 
 
 class IStanBackend(ABC):
-    def __init__(self, logger):
+    def __init__(self):
         self.model = self.load_model()
-        self.logger = logger
         self.stan_fit = None
 
     @staticmethod
@@ -82,7 +83,7 @@ class CmdStanPyBackend(IStanBackend):
         except RuntimeError as e:
             # Fall back on Newton
             if kwargs['algorithm'] != 'Newton':
-                self.logger.warning(
+                logger.warning(
                     'Optimization terminated abnormally. Falling back to Newton.'
                 )
                 kwargs['algorithm'] = 'Newton'
@@ -244,7 +245,7 @@ class PyStanBackend(IStanBackend):
             self.stan_fit = self.model.optimizing(**args)
         except RuntimeError:
             # Fall back on Newton
-            self.logger.warning(
+            logger.warning(
                 'Optimization terminated abnormally. Falling back to Newton.'
             )
             args['algorithm'] = 'Newton'

--- a/python/fbprophet/models.py
+++ b/python/fbprophet/models.py
@@ -12,8 +12,8 @@ from enum import Enum
 import pickle
 import pkg_resources
 import os
-import logging
 
+import logging
 logger = logging.getLogger('fbprophet.models')
 
 


### PR DESCRIPTION
Removed logger attribute from IStanBackend to allow pickling in python3.6. Use generic logger like done in plot.py.

This should fix #1361. 

Testing by running python -m unittest

Also tested the below code without error in python3.6
```
from fbprophet import Prophet
import pickle

with open('test.pickle', 'wb') as f:
   pickle.dump(Prophet(), f)
```