### PR TITLE
Support clear redundant property in prediction.

### DIFF
--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -1619,3 +1619,16 @@ class Prophet(object):
             weekly_start=weekly_start, yearly_start=yearly_start,
             figsize=figsize
         )
+
+
+    def clear_redundancies(self):
+        """Clear the redundant property in a fitted model which only used for prediction.
+
+        predict need `self.history` be not None
+        make_future_dataframe need `self.history_dates` be not None
+        `self.stan_backend` is only used in fit
+        """
+
+        self.history = -1
+        self.history_dates = -1
+        self.stan_backend = None


### PR DESCRIPTION
Hi, 

I am using spark to schedule nearly half million timeseries trainning . I used to pickle model and save in hdfs , the file size is idea after remove `model.history` and `model.history_dates` .
But after update to 0.6,  the disk resource was quickly  eat up . 

I dig several hours to find this out, may not call problem , but it need concern .

- prophet 0.5  save 47898 model in 93M parquet file ( 1.98K per model ). 
- prophet 0.6  save 92 model in 77M parquet file   ( 857K per model ) . 

Since I have 574776 models.  The total size of all model  increased from 1118.4 M to  469G . That is really a disaster.

Then I tried to found which is the most big property by
```
for k in m.__dict__.keys():
    i = m.__dict__[k]
    print(k, len(dill.dumps(i)))
```

output : 
```
seasonality_params_list 714
growth 16
changepoints 1044
n_changepoints 5
specified_changepoints 4
changepoint_range 12
yearly_seasonality 14
weekly_seasonality 4
daily_seasonality 4
holidays 4
seasonality_mode 18
seasonality_prior_scale 12
changepoint_prior_scale 12
holidays_prior_scale 12
mcmc_samples 5
interval_width 12
uncertainty_samples 4
start 65
y_scale 198
logistic_floor 4
t_scale 62
changepoints_t 316
seasonalities 484
extra_regressors 832
country_holidays 4
stan_fit 4
params 993
history 8
history_dates 8
train_component_cols 8765
component_modes 550
train_holiday_names 4
fit_kwargs 21
stan_backend 1908072
```

It turns out to these which doesn't find in 0.5
```
fit_kwargs 21
stan_backend 1908072
```

As I saw, `stan_backend` is only used for fitting , would not use in prediction . 
I think we need a method to clean these redundant/useless property .


