### PR TITLE
Add helper function to summarise coefficients of extra regressors

### DIFF
--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -1565,8 +1565,7 @@ class Prophet(object):
         return pd.DataFrame({'ds': dates})
 
     def regressor_index(self, name):
-        """
-        Given the name of a regressor, return its index in the `beta` matrix.
+        """Given the name of a regressor, return its (column) index in the `beta` matrix.
 
         Parameters
         ----------
@@ -1581,18 +1580,27 @@ class Prophet(object):
         )[0]
 
     def regressor_coefficients(self):
-        """
-        Summarise the coefficients of the extra regressors used in the model.
+        """Summarise the coefficients of the extra regressors used in the model.
+
+        A coefficient represents the incremental impact on `y` of a unit increase
+        in the regressor. For regressors that have been standardized, the unit increase
+        is measured relative to the mean of the regressor (the center value).
+
+        Coefficients are always measured on the original scale of the training data
+        (i.e. `y` and `beta` are transformed back to the original scale).
 
         Returns
         -------
         pd.DataFrame containing:
         - `regressor`: Name of the regressor
-        - `regressor_mode`: Whether the regressor has an additive or multiplicative effect on `y`.
-        - `center`: If the regressor was standardized, the location parameter. The marginal effect of the regressor is measured relative to its center (i.e. how many units above or below the center is the regressor value.)
-        - `coef_lower`: Lower bound for the estimate of the regressor's coefficient.
-        - `coef`: Mean coefficient estimate for the regressor.
-        - `coef_upper`: Upper bound for the estimate of the regressor's coefficient.
+        - `regressor_mode`: Whether the regressor has an additive or multiplicative
+            effect on `y`.
+        - `center`: The mean of the regressor if it was standardized. Otherwise 0.
+        - `coef_lower`: Lower bound for the coefficient, estimated from the MCMC samples.
+            Only different to `coef` if `mcmc_samples > 0`.
+        - `coef`: Expected value of the coefficient.
+        - `coef_upper`: Upper bound for the coefficient, estimated from MCMC samples.
+            Only to different to `coef` if `mcmc_samples > 0`.
         """
         assert len(self.extra_regressors) > 0, 'No extra regressors found.'
         y_max = self.history['y'].max()

--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -1564,66 +1564,6 @@ class Prophet(object):
 
         return pd.DataFrame({'ds': dates})
 
-    def regressor_index(self, name):
-        """Given the name of a regressor, return its (column) index in the `beta` matrix.
-
-        Parameters
-        ----------
-        name: Name of the regressor, as passed into the `add_regressor` function.
-
-        Returns
-        -------
-        The column index of the regressor in the `beta` matrix.
-        """
-        return np.extract(
-            self.train_component_cols[name] == 1, self.train_component_cols.index
-        )[0]
-
-    def regressor_coefficients(self):
-        """Summarise the coefficients of the extra regressors used in the model.
-
-        For additive regressors, the coefficient represents the incremental impact
-        on `y` of a unit increase in the regressor. For multiplicative regressors,
-        the incremental impact is equal to `trend(t)` multiplied by the coefficient.
-
-        Coefficients are measured on the original scale of the training data.
-
-        Returns
-        -------
-        pd.DataFrame containing:
-        - `regressor`: Name of the regressor
-        - `regressor_mode`: Whether the regressor has an additive or multiplicative
-            effect on `y`.
-        - `center`: The mean of the regressor if it was standardized. Otherwise 0.
-        - `coef_lower`: Lower bound for the coefficient, estimated from the MCMC samples.
-            Only different to `coef` if `mcmc_samples > 0`.
-        - `coef`: Expected value of the coefficient.
-        - `coef_upper`: Upper bound for the coefficient, estimated from MCMC samples.
-            Only to different to `coef` if `mcmc_samples > 0`.
-        """
-        assert len(self.extra_regressors) > 0, 'No extra regressors found.'
-        y_max = self.history['y'].max()
-        coefs = []
-        for regressor, params in self.extra_regressors.items():
-            beta = self.params['beta'][:, self.regressor_index(regressor)]
-            coef = beta * y_max / params['std']
-            quantiles = [
-                (1 - self.interval_width) / 2,
-                1 - (1 - self.interval_width) / 2,
-            ]
-            coef_bounds = np.quantile(coef, q=quantiles)
-            record = {
-                'regressor': regressor,
-                'regressor_mode': params['mode'],
-                'center': params['mu'],
-                'coef_lower': coef_bounds[0],
-                'coef': np.mean(coef),
-                'coef_upper': coef_bounds[1],
-            }
-            coefs.append(record)
-
-        return pd.DataFrame(coefs)
-
     def plot(self, fcst, ax=None, uncertainty=True, plot_cap=True,
              xlabel='ds', ylabel='y', figsize=(10, 6)):
         """Plot the Prophet forecast.

--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -1582,12 +1582,11 @@ class Prophet(object):
     def regressor_coefficients(self):
         """Summarise the coefficients of the extra regressors used in the model.
 
-        A coefficient represents the incremental impact on `y` of a unit increase
-        in the regressor. For regressors that have been standardized, the unit increase
-        is measured relative to the mean of the regressor (the center value).
+        For additive regressors, the coefficient represents the incremental impact
+        on `y` of a unit increase in the regressor. For multiplicative regressors,
+        the incremental impact is equal to `trend(t)` multiplied by the coefficient.
 
-        Coefficients are always measured on the original scale of the training data
-        (i.e. `y` and `beta` are transformed back to the original scale).
+        Coefficients are measured on the original scale of the training data.
 
         Returns
         -------

--- a/python/fbprophet/tests/test_utilities.py
+++ b/python/fbprophet/tests/test_utilities.py
@@ -35,8 +35,7 @@ class TestUtilities(TestCase):
         m.fit(df)
 
         coefs = regressor_coefficients(m)
-        self.assertTrue(coefs.shape[0] == 2)
-        self.assertTrue(coefs.shape[1] == 6)
+        self.assertTrue(coefs.shape == (2, 6))
         # No MCMC sampling, so lower and upper should be the same as mean
         self.assertTrue(np.array_equal(coefs['coef_lower'].values, coefs['coef'].values))
         self.assertTrue(np.array_equal(coefs['coef_upper'].values, coefs['coef'].values))

--- a/python/fbprophet/tests/test_utilities.py
+++ b/python/fbprophet/tests/test_utilities.py
@@ -1,0 +1,42 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os
+from unittest import TestCase
+
+import numpy as np
+import pandas as pd
+from fbprophet import Prophet
+from fbprophet.utilities import regressor_coefficients
+
+
+DATA = pd.read_csv(
+    os.path.join(os.path.dirname(__file__), 'data.csv'),
+    parse_dates=['ds'],
+)
+
+class TestUtilities(TestCase):
+    def test_regressor_coefficients(self):
+        m = Prophet()
+        N = DATA.shape[0]
+        df = DATA.copy()
+        np.random.seed(123)
+        df['regr1'] = np.random.normal(size=N)
+        df['regr2'] = np.random.normal(size=N)
+        m.add_regressor('regr1', mode='additive')
+        m.add_regressor('regr2', mode='multiplicative')
+        m.fit(df)
+
+        coefs = regressor_coefficients(m)
+        self.assertTrue(coefs.shape[0] == 2)
+        self.assertTrue(coefs.shape[1] == 6)
+        # No MCMC sampling, so lower and upper should be the same as mean
+        self.assertTrue(np.array_equal(coefs['coef_lower'].values, coefs['coef'].values))
+        self.assertTrue(np.array_equal(coefs['coef_upper'].values, coefs['coef'].values))

--- a/python/fbprophet/utilities.py
+++ b/python/fbprophet/utilities.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+import pandas as pd
+
+def regressor_index(m, name):
+    """Given the name of a regressor, return its (column) index in the `beta` matrix.
+
+    Parameters
+    ----------
+    m: Prophet model object, after fitting.
+    name: Name of the regressor, as passed into the `add_regressor` function.
+
+    Returns
+    -------
+    The column index of the regressor in the `beta` matrix.
+    """
+    return np.extract(
+        m.train_component_cols[name] == 1, m.train_component_cols.index
+    )[0]
+
+def regressor_coefficients(m):
+    """Summarise the coefficients of the extra regressors used in the model.
+
+    For additive regressors, the coefficient represents the incremental impact
+    on `y` of a unit increase in the regressor. For multiplicative regressors,
+    the incremental impact is equal to `trend(t)` multiplied by the coefficient.
+
+    Coefficients are measured on the original scale of the training data.
+
+    Parameters
+    ----------
+    m: Prophet model object, after fitting.
+
+    Returns
+    -------
+    pd.DataFrame containing:
+    - `regressor`: Name of the regressor
+    - `regressor_mode`: Whether the regressor has an additive or multiplicative
+        effect on `y`.
+    - `center`: The mean of the regressor if it was standardized. Otherwise 0.
+    - `coef_lower`: Lower bound for the coefficient, estimated from the MCMC samples.
+        Only different to `coef` if `mcmc_samples > 0`.
+    - `coef`: Expected value of the coefficient.
+    - `coef_upper`: Upper bound for the coefficient, estimated from MCMC samples.
+        Only to different to `coef` if `mcmc_samples > 0`.
+    """
+    assert len(m.extra_regressors) > 0, 'No extra regressors found.'
+    y_max = m.history['y'].max()
+    coefs = []
+    for regressor, params in m.extra_regressors.items():
+        beta = m.params['beta'][:, regressor_index(m, regressor)]
+        if params['mode'] == 'additive':
+            coef = beta * y_max / params['std']
+        else:
+            coef = beta / params['std']
+        percentiles = [
+            (1 - m.interval_width) / 2,
+            1 - (1 - m.interval_width) / 2,
+        ]
+        coef_bounds = np.quantile(coef, q=percentiles)
+        record = {
+            'regressor': regressor,
+            'regressor_mode': params['mode'],
+            'center': params['mu'],
+            'coef_lower': coef_bounds[0],
+            'coef': np.mean(coef),
+            'coef_upper': coef_bounds[1],
+        }
+        coefs.append(record)
+
+    return pd.DataFrame(coefs)


### PR DESCRIPTION
I've seen a few Issues pop up about how to interpret the `beta` matrix / how to get the "coefficient" of an extra regressor, and I was thinking it would be worth having a helper function for this? Specifically, the function would transform the values in `beta` back to the original scale of the data values, and calculate lower / upper bounds if MCMC sampling was done.

Below is my working for the transformations:

* Additive regressor (ignoring seasonality)
```
y_scaled = trend +  beta * x_scaled
y / y_max = trend + beta * ((x - mu) / sigma)
y = trend * y_max + beta * y_max ((x - mu) / sigma)
```
So the incremental impact on `y` of a unit increase in `x` is
```
coef = beta * y_max / sigma
``` 
* For a multiplicative regressor the incremental impact would be `coef * trend(t)`.

Let me know if you guys think this is worth having.
