### PR TITLE
Plot continuous weekly seasonality with sub daily data

### DIFF
--- a/python/fbprophet/plot.py
+++ b/python/fbprophet/plot.py
@@ -150,6 +150,9 @@ def plot_components(
 
     multiplicative_axes = []
 
+    dt = m.history['ds'].diff()
+    min_dt = dt.iloc[dt.values.nonzero()[0]].min() 
+
     for ax, plot_name in zip(axes, components):
         if plot_name == 'trend':
             plot_forecast_component(

--- a/python/fbprophet/plot.py
+++ b/python/fbprophet/plot.py
@@ -397,7 +397,11 @@ def plot_seasonality(m, name, ax=None, uncertainty=True, figsize=(10, 6)):
             df_y['ds'].dt.to_pydatetime(), seas[name + '_lower'],
             seas[name + '_upper'], color='#0072B2', alpha=0.2)]
     ax.grid(True, which='major', c='gray', ls='-', lw=1, alpha=0.2)
-    xticks = pd.to_datetime(np.linspace(start.value, end.value, 7)
+    if name == 'weekly' and period > 1:
+        n_ticks = 8
+    else:
+        n_ticks = 7
+    xticks = pd.to_datetime(np.linspace(start.value, end.value, n_ticks)
         ).to_pydatetime()
     ax.set_xticks(xticks)
     if period <= 2:

--- a/python/fbprophet/plot.py
+++ b/python/fbprophet/plot.py
@@ -402,6 +402,8 @@ def plot_seasonality(m, name, ax=None, uncertainty=True, figsize=(10, 6)):
     ax.set_xticks(xticks)
     if period <= 2:
         fmt_str = '{dt:%T}'
+    elif name == 'weekly':
+        fmt_str = '{dt:%A}'
     elif period < 14:
         fmt_str = '{dt:%m}/{dt:%d} {dt:%R}'
     else:

--- a/python/fbprophet/plot.py
+++ b/python/fbprophet/plot.py
@@ -161,9 +161,14 @@ def plot_components(
             )
         elif plot_name in m.seasonalities:
             if plot_name == 'weekly' or m.seasonalities[plot_name]['period'] == 7:
-                plot_weekly(
-                    m=m, name=plot_name, ax=ax, uncertainty=uncertainty, weekly_start=weekly_start
-                )
+                if min_dt < pd.Timedelta(days=1):
+                    plot_seasonality(
+                        m=m, name=plot_name, ax=ax, uncertainty=uncertainty,
+                    )
+                else:
+                    plot_weekly(
+                        m=m, name=plot_name, ax=ax, uncertainty=uncertainty, weekly_start=weekly_start
+                    )
             elif plot_name == 'yearly' or m.seasonalities[plot_name]['period'] == 365.25:
                 plot_yearly(
                     m=m, name=plot_name, ax=ax, uncertainty=uncertainty, yearly_start=yearly_start


### PR DESCRIPTION
#1557 

This pull request allows Prophet to plot a continuous profile for the weekly component graph of sub daily data.

When calling plot_components(), the frequency of the data is now checked. If data is found to be sub daily, the weekly component will be plotted using plot_seasonality(), else the component will be plotted using plot_weekly(). 

Before (yosemite_temps data):
![image](https://user-images.githubusercontent.com/54314568/89661522-b59a4080-d8ca-11ea-8b26-3c212367b3c1.png)

After Commit 1 & 2 (yosemite_temps data):
![image](https://user-images.githubusercontent.com/54314568/89663755-ef207b00-d8cd-11ea-8163-832043b5c970.png)




This pull request also alters the x labels and ticks, when plot_seasonality() is used for weekly components. It now displays the full weekday name, instead of the datetime. It also shows 8 xticks, to show every day of the week, and to illustrate the continuous nature of the component 

After Commit 3 (7 ticks - yosemite_temps data):
![image](https://user-images.githubusercontent.com/54314568/89664228-ba60f380-d8ce-11ea-8734-cf747740814d.png)

After Commit 4 (yosemite_temps data):
![image](https://user-images.githubusercontent.com/54314568/89659438-ce552700-d8c7-11ea-9059-1d0a4222de7f.png)
