### PR TITLE
resolve python requirements : pandas<1.1.0 

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,7 +2,7 @@ Cython>=0.22
 cmdstanpy==0.9.5
 pystan>=2.14
 numpy>=1.10.0
-pandas>=0.23.4
+pandas>=0.23.4,<1.1.0
 matplotlib>=2.0.0
 LunarCalendar>=0.0.9
 convertdate>=2.1.2


### PR DESCRIPTION
Hi, 
This change is attempting to fix #1607 and #1617, where pandas version need to be less than 1.1.0 (<1.1.0).
Requirements for pandas on `requirements.txt` were made not explicitly to 1.0.5 (which is working for both issues), but in between versions, which is tested and resolved to 1.0.5 anyway. Hopefully this PR can fix those issues, while working on prophet functionality with newer version of pandas.
Please let me know what you think. Cheers.