### PR TITLE
Style: Adding a method docstring

### DIFF
--- a/notebooks/additional_topics.ipynb
+++ b/notebooks/additional_topics.ipynb
@@ -55,6 +55,21 @@
    ],
    "source": [
     "def stan_init(m):\n",
+    "    \"\"\"Retrieving parameters from a trained model.\n",
+    "    \n",
+    "    Retrieved parameters from a trained model \n",
+    "    of the Prophet() Class,are used to initialise \n",
+    "    parameters for a new model. This can help \n",
+    "    speed up training, especially if new data\n",
+    "    follows the same trend as the historical data.\n",
+    "    \n",
+    "    @Param\n",
+    "    m: A trained model of the Prophet() Class\n",
+    "    \n",
+    "    @Return\n",
+    "    res: A Dictionary containing retrieved parameters of m\n",
+    "    \n",
+    "    \"\"\"\n",
     "    res = {}\n",
     "    for pname in ['k', 'm', 'sigma_obs']:\n",
     "        res[pname] = m.params[pname][0][0]\n",
@@ -84,9 +99,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (fbprophet)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "fbprophet"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -98,7 +113,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Adding a docstring to the `stan_init()` method of `additional_topics.ipynb` notebook in the notebooks directory.

This helps to create a descriptive summary of the method, 
its intended use case(s) and expected parameters and return object.