### PR TITLE
fix for comma-separated holidays

### DIFF
--- a/python/fbprophet/make_holidays.py
+++ b/python/fbprophet/make_holidays.py
@@ -61,7 +61,8 @@ def make_holidays_df(year_list, country, province=None):
         except AttributeError as e:
             raise AttributeError(
                 "Holidays in {} are not currently supported!".format(country)) from e
-    holidays_df = pd.DataFrame(list(holidays.items()), columns=['ds', 'holiday'])
+    holidays_df = pd.DataFrame([(date, holidays.get_list(date)) for date in holidays], columns=['ds', 'holiday'])
+    holidays_df = holidays_df.explode('holiday')
     holidays_df.reset_index(inplace=True, drop=True)
     holidays_df['ds'] = pd.to_datetime(holidays_df['ds'])
     return (holidays_df)

--- a/python/fbprophet/make_holidays.py
+++ b/python/fbprophet/make_holidays.py
@@ -40,7 +40,7 @@ def get_holiday_names(country):
     return set(holiday_names)
 
 
-def make_holidays_df(year_list, country, province=None):
+def make_holidays_df(year_list, country, province=None, state=None):
     """Make dataframe of holidays for given years and countries
 
     Parameters
@@ -57,7 +57,7 @@ def make_holidays_df(year_list, country, province=None):
         holidays = getattr(hdays_part2, country)(years=year_list)
     except AttributeError:
         try:
-            holidays = getattr(hdays_part1, country)(prov=province,years=year_list)
+            holidays = getattr(hdays_part1, country)(prov=province, state=state, years=year_list)
         except AttributeError as e:
             raise AttributeError(
                 "Holidays in {} are not currently supported!".format(country)) from e


### PR DESCRIPTION
I also added `state=None` to `make_holidays_df(year_list, country, province=None, state=None)`.

This fixes https://github.com/facebook/prophet/issues/1636 for NL, but now causes new problems with ID:

```
>>> from fbprophet.make_holidays import make_holidays_df
>>> holidays = make_holidays_df(year_list=[2005], country='NL')
>>> print(holidays)
           ds             holiday
0  2005-01-01       Nieuwjaarsdag
1  2005-03-27      Eerste paasdag
2  2005-03-25       Goede Vrijdag
3  2005-03-28      Tweede paasdag
4  2005-05-05      Bevrijdingsdag
5  2005-05-05          Hemelvaart
6  2005-05-15  Eerste Pinksterdag
7  2005-05-16  Tweede Pinksterdag
8  2005-12-25     Eerste Kerstdag
9  2005-12-26     Tweede Kerstdag
10 2005-04-30       Koninginnedag
>>> 
>>> 
>>> holidays = make_holidays_df(year_list=[2015], country='US', state='ID')
>>> print(holidays)
           ds                       holiday
0  2015-01-01                New Year's Day
1  2015-01-19            Martin Luther King
2  2015-01-19  Jr. - Idaho Human Rights Day
3  2015-02-16         Washington's Birthday
4  2015-05-25                  Memorial Day
5  2015-07-04              Independence Day
6  2015-07-03   Independence Day (Observed)
7  2015-09-07                     Labor Day
8  2015-10-12                  Columbus Day
9  2015-11-11                  Veterans Day
10 2015-11-26                  Thanksgiving
11 2015-12-25                 Christmas Day
```