### PR TITLE
[python] Add setup requirements removing the need for a two-step install

### DIFF
--- a/docs/_docs/installation.md
+++ b/docs/_docs/installation.md
@@ -37,13 +37,10 @@ Prophet is on PyPI, so you can use pip to install it:
 
 ```
 # bash
-# Install pystan with pip before using pip to install fbprophet
-$ pip install pystan
-$
 $ pip install fbprophet
 ```
 
-The major dependency that Prophet has is `pystan`. PyStan has its own [installation instructions](http://pystan.readthedocs.io/en/latest/installation_beginner.html). Install pystan with pip before using pip to install fbprophet.
+The major dependency that Prophet has is `pystan`. PyStan has its own [installation instructions](http://pystan.readthedocs.io/en/latest/installation_beginner.html).
 
 After installation, you can [get started!](quick_start.html#python-api)
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -117,7 +117,7 @@ with open('README.md', 'r', encoding='utf-8') as f:
     long_description = f.read()
 
 with open('requirements.txt', 'r') as f:
-    install_requires = f.read().splitlines()
+    requirements = f.read().splitlines()
 
 setup(
     name='fbprophet',
@@ -128,9 +128,8 @@ setup(
     author_email='sjtz@pm.me',
     license='MIT',
     packages=find_packages(),
-    setup_requires=[
-    ],
-    install_requires=install_requires,
+    setup_requires=requirements,
+    install_requires=requirements,
     python_requires='>=3',
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
There is at least one [post](https://discuss.streamlit.io/t/error-when-deploying-with-docker/2873/4), several GitHub issues (https://github.com/facebook/prophet/issues/1551, https://github.com/facebook/prophet/issues/401), and the [Python documentation](https://facebook.github.io/prophet/docs/installation.html#python) which recommends that  you install `pystan` prior to installing `fbprophet` as the build has an _implicit_ dependency on `pystan`, `numpy`, etc.

The issue with this two-step approach is it's problematic when using tools like [`pip-tools`](https://github.com/jazzband/pip-tools), [`pip-compile-multi`](https://github.com/peterdemin/pip-compile-multi), etc. which purposely install/build all the requirements via a single `pip` command, and though `pip` installs "dependencies before dependant", without _explicit_ mention there is no guarantee that certain packages are installed prior to the building of the `fbprophet` package resulting in errors of the form (truncated):

```
Building wheel for fbprophet (setup.py): finished with status 'error'
ModuleNotFoundError: No module named 'numpy'
```

A potentially viable solution (tested) is to _explicitly_ define the requirements (specified in `requirements.txt`) as `setup_requires` which invokes [setuptools.dist.Distribution.fetch_build_eggs](http://code.nabla.net/doc/setuptools/api/setuptools/dist/setuptools.dist.Distribution.html#setuptools.dist.Distribution.fetch_build_eggs) thus ensuring the requirements are installed prior to building the package and removing the need for the two-step approach. 