### PR TITLE
Tqdm flag

### DIFF
--- a/python/fbprophet/diagnostics.py
+++ b/python/fbprophet/diagnostics.py
@@ -186,8 +186,7 @@ def cross_validation(model, horizon, period=None, initial=None, parallel=None, c
 
     else:
         predicts = [
-            single_cutoff_forecast(df, model, cutoff, horizon, predict_columns)
-for cutoff in (tqdm(cutoffs) if not disable_tqdm else cutoffs)
+            single_cutoff_forecast(df, model, cutoff, horizon, predict_columns) for cutoff in (tqdm(cutoffs) if not disable_tqdm else cutoffs)
         ]
 
     # Combine all predicted pd.DataFrame into one pd.DataFrame

--- a/python/fbprophet/diagnostics.py
+++ b/python/fbprophet/diagnostics.py
@@ -187,7 +187,7 @@ def cross_validation(model, horizon, period=None, initial=None, parallel=None, c
     else:
         predicts = [
             single_cutoff_forecast(df, model, cutoff, horizon, predict_columns)
-            for cutoff in (tqdm(cutoffs) if disable_tqdm==False else cutoffs)
+for cutoff in (tqdm(cutoffs) if not disable_tqdm else cutoffs)
         ]
 
     # Combine all predicted pd.DataFrame into one pd.DataFrame

--- a/python/fbprophet/diagnostics.py
+++ b/python/fbprophet/diagnostics.py
@@ -58,7 +58,7 @@ def generate_cutoffs(df, horizon, initial, period):
     return list(reversed(result))
 
 
-def cross_validation(model, horizon, period=None, initial=None, parallel=None, cutoffs=None):
+def cross_validation(model, horizon, period=None, initial=None, parallel=None, cutoffs=None, disable_tqdm=False):
     """Cross-Validation for time series.
 
     Computes forecasts from historical cutoff points, which user can input.
@@ -79,7 +79,7 @@ def cross_validation(model, horizon, period=None, initial=None, parallel=None, c
         period will include at least this much data. If not provided,
         3 * horizon is used.
     cutoffs: list of pd.Timestamp specifying cutoffs to be used during
-        cross validtation. If not provided, they are generated as described
+        cross validation. If not provided, they are generated as described
         above.
     parallel : {None, 'processes', 'threads', 'dask', object}
 
@@ -186,7 +186,7 @@ def cross_validation(model, horizon, period=None, initial=None, parallel=None, c
     else:
         predicts = [
             single_cutoff_forecast(df, model, cutoff, horizon, predict_columns)
-            for cutoff in tqdm(cutoffs)
+            for cutoff in (tqdm(cutoffs) if disable_tqdm==False else cutoffs)
         ]
 
     # Combine all predicted pd.DataFrame into one pd.DataFrame

--- a/python/fbprophet/diagnostics.py
+++ b/python/fbprophet/diagnostics.py
@@ -186,7 +186,8 @@ def cross_validation(model, horizon, period=None, initial=None, parallel=None, c
 
     else:
         predicts = [
-            single_cutoff_forecast(df, model, cutoff, horizon, predict_columns) for cutoff in (tqdm(cutoffs) if not disable_tqdm else cutoffs)
+            single_cutoff_forecast(df, model, cutoff, horizon, predict_columns) 
+            for cutoff in (tqdm(cutoffs) if not disable_tqdm else cutoffs)
         ]
 
     # Combine all predicted pd.DataFrame into one pd.DataFrame

--- a/python/fbprophet/diagnostics.py
+++ b/python/fbprophet/diagnostics.py
@@ -82,6 +82,7 @@ def cross_validation(model, horizon, period=None, initial=None, parallel=None, c
         cross validation. If not provided, they are generated as described
         above.
     parallel : {None, 'processes', 'threads', 'dask', object}
+    disable_tqdm: if True it disables the progress bar that would otherwise show up when parallel=None
 
         How to parallelize the forecast computation. By default no parallelism
         is used.


### PR DESCRIPTION
As discussed in https://github.com/facebook/prophet/issues/1677 this pull requests adds the flag `disable_tqdm` to the cross-validation function. It allows to disable the progress bar that appears when `parallel` is set to _None_.
