### PR TITLE
[python] Add attribute to fit method to allow custom column names

### DIFF
--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -1097,9 +1097,18 @@ class Prophet(object):
         """
        
         if date_col:
-             df.rename(columns={date_col:'ds'}, inplace=True)
+            if (date_col not in df):
+                raise ValueError(
+                        'The value given to date_col \'' + date_col + '\' does not exsist as a column value in the dataframe. \n' 
+                        'use a column value that exsist for date_col.')
+            df.rename(columns={date_col:'ds'}, inplace=True)
+
         if y_col:
-             df.rename(columns={y_col:'y'}, inplace=True)
+            if (y_col not in df):
+                raise ValueError(
+                        'The value given to date_col \'' + date_col + '\' does not exsist as a column value in the dataframe. \n' 
+                        'use a column value that exsist for date_col.')
+            df.rename(columns={y_col:'y'}, inplace=True)
 
         if self.history is not None:
             raise Exception('Prophet object can only be fit once. '

--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -73,9 +73,6 @@ class Prophet(object):
         uncertainty estimation and speed up the calculation.
     stan_backend: str as defined in StanBackendEnum default: None - will try to
         iterate over all available backends and find the working one
-    date_col: str of the name of the column that is containing the dates we want
-        to examine
-    y_col: str of the column containing the data that contains the y info
     """
 
     def __init__(
@@ -95,16 +92,13 @@ class Prophet(object):
             mcmc_samples=0,
             interval_width=0.80,
             uncertainty_samples=1000,
-            stan_backend=None,
-            date_col='ds',
-            y_col='y'
-
+            stan_backend=None
     ):
         self.growth = growth
 
         self.changepoints = changepoints
         if self.changepoints is not None:
-            self.changepoints = pd.Series(pd.to_datetime(self.changepoints), name=self.date_col)
+            self.changepoints = pd.Series(pd.to_datetime(self.changepoints), name='ds')
             self.n_changepoints = len(self.changepoints)
             self.specified_changepoints = True
         else:
@@ -169,12 +163,12 @@ class Prophet(object):
         if self.holidays is not None:
             if not (
                 isinstance(self.holidays, pd.DataFrame)
-                and self.date_col in self.holidays  # noqa W503
+                and 'ds' in self.holidays  # noqa W503
                 and 'holiday' in self.holidays  # noqa W503
             ):
                 raise ValueError('holidays must be a DataFrame with "ds" and '
                                  '"holiday" columns.')
-            self.holidays[self.date_col] = pd.to_datetime(self.holidays[self.date_col])
+            self.holidays['ds'] = pd.to_datetime(self.holidays['ds'])
             has_lower = 'lower_window' in self.holidays
             has_upper = 'upper_window' in self.holidays
             if has_lower + has_upper == 1:
@@ -215,7 +209,7 @@ class Prophet(object):
         reserved_names.extend(rn_l)
         reserved_names.extend(rn_u)
         reserved_names.extend([
-            self.date_col, self.y_col, 'cap', 'floor', 'y_scaled', 'cap_scaled'])
+            'ds', 'y', 'cap', 'floor', 'y_scaled', 'cap_scaled'])
         if name in reserved_names:
             raise ValueError(
                 'Name {name!r} is reserved.'.format(name=name)
@@ -259,19 +253,19 @@ class Prophet(object):
         -------
         pd.DataFrame prepared for fitting or predicting.
         """
-        if self.y_col in df:  # 'y' will be in training data
-            df[self.y_col] = pd.to_numeric(df[self.y_col])
-            if np.isinf(df[self.y_col].values).any():
+        if 'y' in df:  # 'y' will be in training data
+            df['y'] = pd.to_numeric(df['y'])
+            if np.isinf(df['y'].values).any():
                 raise ValueError('Found infinity in column y.')
-        if df[self.date_col].dtype == np.int64:
-            df[self.date_col] = df[self.date_col].astype(str)
-        df[self.date_col] = pd.to_datetime(df[self.date_col])
-        if df[self.date_col].dt.tz is not None:
+        if df['ds'].dtype == np.int64:
+            df['ds'] = df['ds'].astype(str)
+        df['ds'] = pd.to_datetime(df['ds'])
+        if df['ds'].dt.tz is not None:
             raise ValueError(
                 'Column ds has timezone specified, which is not supported. '
                 'Remove timezone.'
             )
-        if df[self.date_col].isnull().any():
+        if df['ds'].isnull().any():
             raise ValueError('Found NaN in column ds.')
         for name in self.extra_regressors:
             if name not in df:
@@ -299,9 +293,9 @@ class Prophet(object):
                     )
                 df[condition_name] = df[condition_name].astype('bool')
 
-        if df.index.name == self.date_col:
+        if df.index.name == 'ds':
             df.index.name = None
-        df = df.sort_values(self.date_col)
+        df = df.sort_values('ds')
         df = df.reset_index(drop=True)
 
         self.initialize_scales(initialize_scales, df)
@@ -323,9 +317,9 @@ class Prophet(object):
                 )
             df['cap_scaled'] = (df['cap'] - df['floor']) / self.y_scale
 
-        df['t'] = (df[self.date_col] - self.start) / self.t_scale
-        if self.y_col in df:
-            df['y_scaled'] = (df[self.y_col] - df['floor']) / self.y_scale
+        df['t'] = (df['ds'] - self.start) / self.t_scale
+        if 'y' in df:
+            df['y_scaled'] = (df['y'] - df['floor']) / self.y_scale
 
         for name, props in self.extra_regressors.items():
             df[name] = ((df[name] - props['mu']) / props['std'])
@@ -348,11 +342,11 @@ class Prophet(object):
             floor = df['floor']
         else:
             floor = 0.
-        self.y_scale = (df[self.y_col] - floor).abs().max()
+        self.y_scale = (df['y'] - floor).abs().max()
         if self.y_scale == 0:
             self.y_scale = 1
-        self.start = df[self.date_col].min()
-        self.t_scale = df[self.date_col].max() - self.start
+        self.start = df['ds'].min()
+        self.t_scale = df['ds'].max() - self.start
         for name, props in self.extra_regressors.items():
             standardize = props['standardize']
             n_vals = len(df[name].unique())
@@ -383,8 +377,8 @@ class Prophet(object):
             if len(self.changepoints) == 0:
                 pass
             else:
-                too_low = min(self.changepoints) < self.history[self.date_col].min()
-                too_high = max(self.changepoints) > self.history[self.date_col].max()
+                too_low = min(self.changepoints) < self.history['ds'].min()
+                too_high = max(self.changepoints) > self.history['ds'].max()
                 if too_low or too_high:
                     raise ValueError(
                         'Changepoints must fall within training data.')
@@ -407,11 +401,11 @@ class Prophet(object):
                         .astype(np.int)
                 )
                 self.changepoints = (
-                    self.history.iloc[cp_indexes][self.date_col].tail(-1)
+                    self.history.iloc[cp_indexes]['ds'].tail(-1)
                 )
             else:
                 # set empty changepoints
-                self.changepoints = pd.Series(pd.to_datetime([]), name=self.date_col)
+                self.changepoints = pd.Series(pd.to_datetime([]), name='ds')
         if len(self.changepoints) > 0:
             self.changepoints_t = np.sort(np.array(
                 (self.changepoints - self.start) / self.t_scale))
@@ -769,7 +763,7 @@ class Prophet(object):
         # Seasonality features
         for name, props in self.seasonalities.items():
             features = self.make_seasonality_features(
-                df[self.date_col],
+                df['ds'],
                 props['period'],
                 props['fourier_order'],
                 name,
@@ -782,10 +776,10 @@ class Prophet(object):
             modes[props['mode']].append(name)
 
         # Holiday features
-        holidays = self.construct_holiday_dataframe(df[self.date_col])
+        holidays = self.construct_holiday_dataframe(df['ds'])
         if len(holidays) > 0:
             features, holiday_priors, holiday_names = (
-                self.make_holiday_features(df[self.date_col], holidays)
+                self.make_holiday_features(df['ds'], holidays)
             )
             seasonal_features.append(features)
             prior_scales.extend(holiday_priors)
@@ -943,9 +937,9 @@ class Prophet(object):
         Turns on daily seasonality if there is >=2 days of history, and the
         spacing between dates in the history is <1 day.
         """
-        first = self.history[self.date_col].min()
-        last = self.history[self.date_col].max()
-        dt = self.history[self.date_col].diff()
+        first = self.history['ds'].min()
+        last = self.history['ds'].max()
+        dt = self.history['ds'].diff()
         min_dt = dt.iloc[dt.values.nonzero()[0]].min()
 
         # Yearly seasonality
@@ -1007,7 +1001,7 @@ class Prophet(object):
         A tuple (k, m) with the rate (k) and offset (m) of the linear growth
         function.
         """
-        i0, i1 = df[self.date_col].idxmin(), df[self.date_col].idxmax()
+        i0, i1 = df['ds'].idxmin(), df['ds'].idxmax()
         T = df['t'].iloc[i1] - df['t'].iloc[i0]
         k = (df['y_scaled'].iloc[i1] - df['y_scaled'].iloc[i0]) / T
         m = df['y_scaled'].iloc[i0] - k * df['t'].iloc[i0]
@@ -1031,7 +1025,7 @@ class Prophet(object):
         A tuple (k, m) with the rate (k) and offset (m) of the logistic growth
         function.
         """
-        i0, i1 = df[self.date_col].idxmin(), df[self.date_col].idxmax()
+        i0, i1 = df['ds'].idxmin(), df['ds'].idxmax()
         T = df['t'].iloc[i1] - df['t'].iloc[i0]
 
         # Force valid values, in case y > cap or y < 0
@@ -1076,7 +1070,7 @@ class Prophet(object):
         m = df['y_scaled'].mean()
         return k, m
 
-    def fit(self, df, **kwargs):
+    def fit(self, df, date_col='ds', y_col='y', **kwargs):
         """Fit the Prophet model.
 
         This sets self.params to contain the fitted model parameters. It is a
@@ -1101,18 +1095,24 @@ class Prophet(object):
         -------
         The fitted Prophet object.
         """
+       
+        if date_col:
+             df.rename(columns={date_col:'ds'}, inplace=True)
+        if y_col:
+             df.rename(columns={y_col:'y'}, inplace=True)
+
         if self.history is not None:
             raise Exception('Prophet object can only be fit once. '
                             'Instantiate a new object.')
-        if (self.date_col not in df) or (self.y_col not in df):
+        if ('ds' not in df) or ('y' not in df):
             raise ValueError(
                 'Dataframe must have columns "ds" and "y" with the dates and '
                 'values respectively.'
             )
-        history = df[df[self.y_col].notnull()].copy()
+        history = df[df['y'].notnull()].copy()
         if history.shape[0] < 2:
             raise ValueError('Dataframe has less than 2 non-NaN rows.')
-        self.history_dates = pd.to_datetime(pd.Series(df[self.date_col].unique(), name=self.date_col)).sort_values()
+        self.history_dates = pd.to_datetime(pd.Series(df['ds'].unique(), name='ds')).sort_values()
 
         history = self.setup_dataframe(history, initialize_scales=True)
         self.history = history
@@ -1131,7 +1131,7 @@ class Prophet(object):
             'T': history.shape[0],
             'K': seasonal_features.shape[1],
             'S': len(self.changepoints_t),
-            self.y_col: history['y_scaled'],
+            'y': history['y_scaled'],
             't': history['t'],
             't_change': self.changepoints_t,
             'X': seasonal_features,
@@ -1160,7 +1160,7 @@ class Prophet(object):
             'sigma_obs': 1,
         }
 
-        if history[self.y_col].min() == history[self.y_col].max() and \
+        if history['y'].min() == history['y'].max() and \
                 (self.growth == 'linear' or self.growth == 'flat'):
             self.params = stan_init
             self.params['sigma_obs'] = 1e-9
@@ -1212,7 +1212,7 @@ class Prophet(object):
             intervals = None
 
         # Drop columns except ds, cap, floor, and trend
-        cols = [self.date_col, 'trend']
+        cols = ['ds', 'trend']
         if 'cap' in df:
             cols.append('cap')
         if self.logistic_floor:
@@ -1574,10 +1574,10 @@ class Prophet(object):
         if include_history:
             dates = np.concatenate((np.array(self.history_dates), dates))
 
-        return pd.DataFrame({self.date_col: dates})
+        return pd.DataFrame({'ds': dates})
 
     def plot(self, fcst, ax=None, uncertainty=True, plot_cap=True,
-             xlabel=self.date_col, ylabel='y', figsize=(10, 6)):
+             xlabel='ds', ylabel='y', figsize=(10, 6)):
         """Plot the Prophet forecast.
 
         Parameters

--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -486,7 +486,7 @@ class Prophet(object):
         if self.country_holidays is not None:
             year_list = list({x.year for x in dates})
             country_holidays_df = make_holidays_df(
-                year_list=year_list, country=self.country_holidays
+                year_list=year_list, country=self.country_holidays, xlabel=self.date_col
             )
             all_holidays = pd.concat((all_holidays, country_holidays_df),
                                      sort=False)
@@ -1105,7 +1105,6 @@ class Prophet(object):
                         'The value given to date_col \'' + date_col + '\' does not exsist as a column value in the dataframe. \n' 
                         'use a column value that exsist for date_col.')
             self.date_col = date_col
-            #df.rename(columns={date_col:'ds'}, inplace=True)
 
         if y_col:
             if (y_col not in df):
@@ -1113,7 +1112,6 @@ class Prophet(object):
                         'The value given to date_col \'' + date_col + '\' does not exsist as a column value in the dataframe. \n' 
                         'use a column value that exsist for date_col.')
             self.y_col = y_col
-            #df.rename(columns={y_col:'y'}, inplace=True)
 
         if self.history is not None:
             raise Exception('Prophet object can only be fit once. '

--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -1011,7 +1011,7 @@ class Prophet(object):
         return (k, m)
 
     @staticmethod
-    def logistic_growth_init(df):
+    def logistic_growth_init(df, date_col='ds'):
         """Initialize logistic growth.
 
         Provides a strong initialization for logistic growth by calculating the
@@ -1028,7 +1028,7 @@ class Prophet(object):
         A tuple (k, m) with the rate (k) and offset (m) of the logistic growth
         function.
         """
-        i0, i1 = df[self.date_col].idxmin(), df[self.date_col].idxmax()
+        i0, i1 = df[date_col].idxmin(), df[date_col].idxmax()
         T = df['t'].iloc[i1] - df['t'].iloc[i0]
 
         # Force valid values, in case y > cap or y < 0

--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -1607,7 +1607,6 @@ class Prophet(object):
         -------
         A matplotlib figure.
         """
-        print(self.date_col)
         return plot(
             m=self, fcst=fcst, ax=ax, uncertainty=uncertainty,
             plot_cap=plot_cap, figsize=figsize

--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -1119,7 +1119,8 @@ class Prophet(object):
         if (self.date_col not in df) or (self.y_col not in df):
             raise ValueError(
                 'Dataframe must have columns "ds" and "y" with the dates and '
-                'values respectively.'
+                'values respectively. Else must be defined with `date_col` and `y_col`'
+                'arguments'
             )
         history = df[df[self.y_col].notnull()].copy()
         if history.shape[0] < 2:

--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -73,6 +73,9 @@ class Prophet(object):
         uncertainty estimation and speed up the calculation.
     stan_backend: str as defined in StanBackendEnum default: None - will try to
         iterate over all available backends and find the working one
+    date_col: str of the name of the column that is containing the dates we want
+        to examine
+    y_col: str of the column containing the data that contains the y info
     """
 
     def __init__(
@@ -92,13 +95,16 @@ class Prophet(object):
             mcmc_samples=0,
             interval_width=0.80,
             uncertainty_samples=1000,
-            stan_backend=None
+            stan_backend=None,
+            date_col='ds',
+            y_col='y'
+
     ):
         self.growth = growth
 
         self.changepoints = changepoints
         if self.changepoints is not None:
-            self.changepoints = pd.Series(pd.to_datetime(self.changepoints), name='ds')
+            self.changepoints = pd.Series(pd.to_datetime(self.changepoints), name=self.date_col)
             self.n_changepoints = len(self.changepoints)
             self.specified_changepoints = True
         else:
@@ -163,12 +169,12 @@ class Prophet(object):
         if self.holidays is not None:
             if not (
                 isinstance(self.holidays, pd.DataFrame)
-                and 'ds' in self.holidays  # noqa W503
+                and self.date_col in self.holidays  # noqa W503
                 and 'holiday' in self.holidays  # noqa W503
             ):
                 raise ValueError('holidays must be a DataFrame with "ds" and '
                                  '"holiday" columns.')
-            self.holidays['ds'] = pd.to_datetime(self.holidays['ds'])
+            self.holidays[self.date_col] = pd.to_datetime(self.holidays[self.date_col])
             has_lower = 'lower_window' in self.holidays
             has_upper = 'upper_window' in self.holidays
             if has_lower + has_upper == 1:
@@ -209,7 +215,7 @@ class Prophet(object):
         reserved_names.extend(rn_l)
         reserved_names.extend(rn_u)
         reserved_names.extend([
-            'ds', 'y', 'cap', 'floor', 'y_scaled', 'cap_scaled'])
+            self.date_col, self.y_col, 'cap', 'floor', 'y_scaled', 'cap_scaled'])
         if name in reserved_names:
             raise ValueError(
                 'Name {name!r} is reserved.'.format(name=name)
@@ -253,19 +259,19 @@ class Prophet(object):
         -------
         pd.DataFrame prepared for fitting or predicting.
         """
-        if 'y' in df:  # 'y' will be in training data
-            df['y'] = pd.to_numeric(df['y'])
-            if np.isinf(df['y'].values).any():
+        if self.y_col in df:  # 'y' will be in training data
+            df[self.y_col] = pd.to_numeric(df[self.y_col])
+            if np.isinf(df[self.y_col].values).any():
                 raise ValueError('Found infinity in column y.')
-        if df['ds'].dtype == np.int64:
-            df['ds'] = df['ds'].astype(str)
-        df['ds'] = pd.to_datetime(df['ds'])
-        if df['ds'].dt.tz is not None:
+        if df[self.date_col].dtype == np.int64:
+            df[self.date_col] = df[self.date_col].astype(str)
+        df[self.date_col] = pd.to_datetime(df[self.date_col])
+        if df[self.date_col].dt.tz is not None:
             raise ValueError(
                 'Column ds has timezone specified, which is not supported. '
                 'Remove timezone.'
             )
-        if df['ds'].isnull().any():
+        if df[self.date_col].isnull().any():
             raise ValueError('Found NaN in column ds.')
         for name in self.extra_regressors:
             if name not in df:
@@ -293,9 +299,9 @@ class Prophet(object):
                     )
                 df[condition_name] = df[condition_name].astype('bool')
 
-        if df.index.name == 'ds':
+        if df.index.name == self.date_col:
             df.index.name = None
-        df = df.sort_values('ds')
+        df = df.sort_values(self.date_col)
         df = df.reset_index(drop=True)
 
         self.initialize_scales(initialize_scales, df)
@@ -317,9 +323,9 @@ class Prophet(object):
                 )
             df['cap_scaled'] = (df['cap'] - df['floor']) / self.y_scale
 
-        df['t'] = (df['ds'] - self.start) / self.t_scale
-        if 'y' in df:
-            df['y_scaled'] = (df['y'] - df['floor']) / self.y_scale
+        df['t'] = (df[self.date_col] - self.start) / self.t_scale
+        if self.y_col in df:
+            df['y_scaled'] = (df[self.y_col] - df['floor']) / self.y_scale
 
         for name, props in self.extra_regressors.items():
             df[name] = ((df[name] - props['mu']) / props['std'])
@@ -342,11 +348,11 @@ class Prophet(object):
             floor = df['floor']
         else:
             floor = 0.
-        self.y_scale = (df['y'] - floor).abs().max()
+        self.y_scale = (df[self.y_col] - floor).abs().max()
         if self.y_scale == 0:
             self.y_scale = 1
-        self.start = df['ds'].min()
-        self.t_scale = df['ds'].max() - self.start
+        self.start = df[self.date_col].min()
+        self.t_scale = df[self.date_col].max() - self.start
         for name, props in self.extra_regressors.items():
             standardize = props['standardize']
             n_vals = len(df[name].unique())
@@ -377,8 +383,8 @@ class Prophet(object):
             if len(self.changepoints) == 0:
                 pass
             else:
-                too_low = min(self.changepoints) < self.history['ds'].min()
-                too_high = max(self.changepoints) > self.history['ds'].max()
+                too_low = min(self.changepoints) < self.history[self.date_col].min()
+                too_high = max(self.changepoints) > self.history[self.date_col].max()
                 if too_low or too_high:
                     raise ValueError(
                         'Changepoints must fall within training data.')
@@ -401,11 +407,11 @@ class Prophet(object):
                         .astype(np.int)
                 )
                 self.changepoints = (
-                    self.history.iloc[cp_indexes]['ds'].tail(-1)
+                    self.history.iloc[cp_indexes][self.date_col].tail(-1)
                 )
             else:
                 # set empty changepoints
-                self.changepoints = pd.Series(pd.to_datetime([]), name='ds')
+                self.changepoints = pd.Series(pd.to_datetime([]), name=self.date_col)
         if len(self.changepoints) > 0:
             self.changepoints_t = np.sort(np.array(
                 (self.changepoints - self.start) / self.t_scale))
@@ -763,7 +769,7 @@ class Prophet(object):
         # Seasonality features
         for name, props in self.seasonalities.items():
             features = self.make_seasonality_features(
-                df['ds'],
+                df[self.date_col],
                 props['period'],
                 props['fourier_order'],
                 name,
@@ -776,10 +782,10 @@ class Prophet(object):
             modes[props['mode']].append(name)
 
         # Holiday features
-        holidays = self.construct_holiday_dataframe(df['ds'])
+        holidays = self.construct_holiday_dataframe(df[self.date_col])
         if len(holidays) > 0:
             features, holiday_priors, holiday_names = (
-                self.make_holiday_features(df['ds'], holidays)
+                self.make_holiday_features(df[self.date_col], holidays)
             )
             seasonal_features.append(features)
             prior_scales.extend(holiday_priors)
@@ -937,9 +943,9 @@ class Prophet(object):
         Turns on daily seasonality if there is >=2 days of history, and the
         spacing between dates in the history is <1 day.
         """
-        first = self.history['ds'].min()
-        last = self.history['ds'].max()
-        dt = self.history['ds'].diff()
+        first = self.history[self.date_col].min()
+        last = self.history[self.date_col].max()
+        dt = self.history[self.date_col].diff()
         min_dt = dt.iloc[dt.values.nonzero()[0]].min()
 
         # Yearly seasonality
@@ -1001,7 +1007,7 @@ class Prophet(object):
         A tuple (k, m) with the rate (k) and offset (m) of the linear growth
         function.
         """
-        i0, i1 = df['ds'].idxmin(), df['ds'].idxmax()
+        i0, i1 = df[self.date_col].idxmin(), df[self.date_col].idxmax()
         T = df['t'].iloc[i1] - df['t'].iloc[i0]
         k = (df['y_scaled'].iloc[i1] - df['y_scaled'].iloc[i0]) / T
         m = df['y_scaled'].iloc[i0] - k * df['t'].iloc[i0]
@@ -1025,7 +1031,7 @@ class Prophet(object):
         A tuple (k, m) with the rate (k) and offset (m) of the logistic growth
         function.
         """
-        i0, i1 = df['ds'].idxmin(), df['ds'].idxmax()
+        i0, i1 = df[self.date_col].idxmin(), df[self.date_col].idxmax()
         T = df['t'].iloc[i1] - df['t'].iloc[i0]
 
         # Force valid values, in case y > cap or y < 0
@@ -1098,15 +1104,15 @@ class Prophet(object):
         if self.history is not None:
             raise Exception('Prophet object can only be fit once. '
                             'Instantiate a new object.')
-        if ('ds' not in df) or ('y' not in df):
+        if (self.date_col not in df) or (self.y_col not in df):
             raise ValueError(
                 'Dataframe must have columns "ds" and "y" with the dates and '
                 'values respectively.'
             )
-        history = df[df['y'].notnull()].copy()
+        history = df[df[self.y_col].notnull()].copy()
         if history.shape[0] < 2:
             raise ValueError('Dataframe has less than 2 non-NaN rows.')
-        self.history_dates = pd.to_datetime(pd.Series(df['ds'].unique(), name='ds')).sort_values()
+        self.history_dates = pd.to_datetime(pd.Series(df[self.date_col].unique(), name=self.date_col)).sort_values()
 
         history = self.setup_dataframe(history, initialize_scales=True)
         self.history = history
@@ -1125,7 +1131,7 @@ class Prophet(object):
             'T': history.shape[0],
             'K': seasonal_features.shape[1],
             'S': len(self.changepoints_t),
-            'y': history['y_scaled'],
+            self.y_col: history['y_scaled'],
             't': history['t'],
             't_change': self.changepoints_t,
             'X': seasonal_features,
@@ -1154,7 +1160,7 @@ class Prophet(object):
             'sigma_obs': 1,
         }
 
-        if history['y'].min() == history['y'].max() and \
+        if history[self.y_col].min() == history[self.y_col].max() and \
                 (self.growth == 'linear' or self.growth == 'flat'):
             self.params = stan_init
             self.params['sigma_obs'] = 1e-9
@@ -1206,7 +1212,7 @@ class Prophet(object):
             intervals = None
 
         # Drop columns except ds, cap, floor, and trend
-        cols = ['ds', 'trend']
+        cols = [self.date_col, 'trend']
         if 'cap' in df:
             cols.append('cap')
         if self.logistic_floor:
@@ -1568,10 +1574,10 @@ class Prophet(object):
         if include_history:
             dates = np.concatenate((np.array(self.history_dates), dates))
 
-        return pd.DataFrame({'ds': dates})
+        return pd.DataFrame({self.date_col: dates})
 
     def plot(self, fcst, ax=None, uncertainty=True, plot_cap=True,
-             xlabel='ds', ylabel='y', figsize=(10, 6)):
+             xlabel=self.date_col, ylabel='y', figsize=(10, 6)):
         """Plot the Prophet forecast.
 
         Parameters

--- a/python/fbprophet/make_holidays.py
+++ b/python/fbprophet/make_holidays.py
@@ -40,7 +40,7 @@ def get_holiday_names(country):
     return set(holiday_names)
 
 
-def make_holidays_df(year_list, country, province=None, state=None):
+def make_holidays_df(year_list, country, province=None, state=None, xlabel='ds'):
     """Make dataframe of holidays for given years and countries
 
     Parameters
@@ -61,8 +61,8 @@ def make_holidays_df(year_list, country, province=None, state=None):
         except AttributeError as e:
             raise AttributeError(
                 "Holidays in {} are not currently supported!".format(country)) from e
-    holidays_df = pd.DataFrame([(date, holidays.get_list(date)) for date in holidays], columns=['ds', 'holiday'])
+    holidays_df = pd.DataFrame([(date, holidays.get_list(date)) for date in holidays], columns=[xlabel, 'holiday'])
     holidays_df = holidays_df.explode('holiday')
     holidays_df.reset_index(inplace=True, drop=True)
-    holidays_df['ds'] = pd.to_datetime(holidays_df['ds'])
+    holidays_df[xlabel] = pd.to_datetime(holidays_df[xlabel])
     return (holidays_df)

--- a/python/fbprophet/plot.py
+++ b/python/fbprophet/plot.py
@@ -88,7 +88,7 @@ def plot(
 
 def plot_components(
     m, fcst, uncertainty=True, plot_cap=True, weekly_start=0, yearly_start=0,
-    figsize=None 
+    figsize=None
 ):
     """Plot the Prophet forecast components.
 
@@ -154,7 +154,7 @@ def plot_components(
         if plot_name == 'trend':
             plot_forecast_component(
                 m=m, fcst=fcst, name='trend', ax=ax, uncertainty=uncertainty,
-                plot_cap=plot_cap, 
+                plot_cap=plot_cap,
             )
         elif plot_name in m.seasonalities:
             if (
@@ -192,7 +192,7 @@ def plot_components(
 
 
 def plot_forecast_component(
-    m, fcst, name, ax=None, uncertainty=True, plot_cap=False, figsize=(10, 6), 
+    m, fcst, name, ax=None, uncertainty=True, plot_cap=False, figsize=(10, 6),
 ):
     """Plot a particular component of the forecast.
 
@@ -239,7 +239,7 @@ def plot_forecast_component(
     return artists
 
 
-def seasonality_plot_df(m, ds ):
+def seasonality_plot_df(m, ds):
     """Prepare dataframe for plotting seasonal components.
 
     Parameters
@@ -259,12 +259,11 @@ def seasonality_plot_df(m, ds ):
         if props['condition_name'] is not None:
             df_dict[props['condition_name']] = True
     df = pd.DataFrame(df_dict)
-    display(df)
     df = m.setup_dataframe(df)
     return df
 
 
-def plot_weekly(m, ax=None, uncertainty=True, weekly_start=0, figsize=(10, 6), name='weekly' ):
+def plot_weekly(m, ax=None, uncertainty=True, weekly_start=0, figsize=(10, 6), name='weekly'):
     """Plot the weekly component of the forecast.
 
     Parameters
@@ -291,7 +290,7 @@ def plot_weekly(m, ax=None, uncertainty=True, weekly_start=0, figsize=(10, 6), n
     # Compute weekly seasonality for a Sun-Sat sequence of dates.
     days = (pd.date_range(start='2017-01-01', periods=7) +
             pd.Timedelta(days=weekly_start))
-    df_w = seasonality_plot_df(m, days )
+    df_w = seasonality_plot_df(m, days)
     seas = m.predict_seasonal_components(df_w)
     days = days.day_name()
     artists += ax.plot(range(len(days)), seas[name], ls='-',
@@ -310,7 +309,7 @@ def plot_weekly(m, ax=None, uncertainty=True, weekly_start=0, figsize=(10, 6), n
     return artists
 
 
-def plot_yearly(m, ax=None, uncertainty=True, yearly_start=0, figsize=(10, 6), name='yearly',):
+def plot_yearly(m, ax=None, uncertainty=True, yearly_start=0, figsize=(10, 6), name='yearly'):
     """Plot the yearly component of the forecast.
 
     Parameters
@@ -357,7 +356,7 @@ def plot_yearly(m, ax=None, uncertainty=True, yearly_start=0, figsize=(10, 6), n
     return artists
 
 
-def plot_seasonality(m, name, ax=None, uncertainty=True, figsize=(10, 6), ):
+def plot_seasonality(m, name, ax=None, uncertainty=True, figsize=(10, 6)):
     """Plot a custom seasonal component.
 
     Parameters
@@ -433,7 +432,8 @@ def set_y_as_percent(ax):
 
 
 def add_changepoints_to_plot(
-    ax, m, fcst, threshold=0.01, cp_color='r', cp_linestyle='--', trend=True, ):
+    ax, m, fcst, threshold=0.01, cp_color='r', cp_linestyle='--', trend=True, 
+):
     """Add markers for significant changepoints to prophet forecast plot.
 
     Example:
@@ -818,7 +818,7 @@ def plot_seasonality_plotly(m, name, uncertainty=True, figsize=(900, 300)):
     return fig
 
 
-def get_forecast_component_plotly_props(m, fcst, name, uncertainty=True, plot_cap=False, ):
+def get_forecast_component_plotly_props(m, fcst, name, uncertainty=True, plot_cap=False):
     """Prepares a dictionary for plotting the selected forecast component with Plotly
 
     Parameters
@@ -924,7 +924,7 @@ def get_forecast_component_plotly_props(m, fcst, name, uncertainty=True, plot_ca
     return {'traces': traces, 'xaxis': xaxis, 'yaxis': yaxis}
 
 
-def get_seasonality_plotly_props(m, name, uncertainty=True, ):
+def get_seasonality_plotly_props(m, name, uncertainty=True):
     """Prepares a dictionary for plotting the selected seasonality with Plotly
 
     Parameters

--- a/python/fbprophet/plot.py
+++ b/python/fbprophet/plot.py
@@ -88,7 +88,8 @@ def plot(
 
 def plot_components(
     m, fcst, uncertainty=True, plot_cap=True, weekly_start=0, yearly_start=0,
-    figsize=None, ):
+    figsize=None 
+):
     """Plot the Prophet forecast components.
 
     Will plot whichever are available of: trend, holidays, weekly
@@ -153,7 +154,7 @@ def plot_components(
         if plot_name == 'trend':
             plot_forecast_component(
                 m=m, fcst=fcst, name='trend', ax=ax, uncertainty=uncertainty,
-                plot_cap=plot_cap 
+                plot_cap=plot_cap, 
             )
         elif plot_name in m.seasonalities:
             if (
@@ -178,7 +179,7 @@ def plot_components(
         ]:
             plot_forecast_component(
                 m=m, fcst=fcst, name=plot_name, ax=ax, uncertainty=uncertainty,
-                plot_cap=False, xlabel=m.date_col
+                plot_cap=False,
             )
         if plot_name in m.component_modes['multiplicative']:
             multiplicative_axes.append(ax)
@@ -238,7 +239,7 @@ def plot_forecast_component(
     return artists
 
 
-def seasonality_plot_df(m, ds, xlabel='ds' ):
+def seasonality_plot_df(m, ds ):
     """Prepare dataframe for plotting seasonal components.
 
     Parameters
@@ -290,7 +291,7 @@ def plot_weekly(m, ax=None, uncertainty=True, weekly_start=0, figsize=(10, 6), n
     # Compute weekly seasonality for a Sun-Sat sequence of dates.
     days = (pd.date_range(start='2017-01-01', periods=7) +
             pd.Timedelta(days=weekly_start))
-    df_w = seasonality_plot_df(m, days, xlabel='weekly')
+    df_w = seasonality_plot_df(m, days )
     seas = m.predict_seasonal_components(df_w)
     days = days.day_name()
     artists += ax.plot(range(len(days)), seas[name], ls='-',
@@ -336,7 +337,7 @@ def plot_yearly(m, ax=None, uncertainty=True, yearly_start=0, figsize=(10, 6), n
     # Compute yearly seasonality for a Jan 1 - Dec 31 sequence of dates.
     days = (pd.date_range(start='2017-01-01', periods=365) +
             pd.Timedelta(days=yearly_start))
-    df_y = seasonality_plot_df(m, days, xlabel=m.date_col)
+    df_y = seasonality_plot_df(m, days)
     seas = m.predict_seasonal_components(df_y)
     artists += ax.plot(
         df_y[m.date_col].dt.to_pydatetime(), seas[name], ls='-', c='#0072B2')
@@ -383,7 +384,7 @@ def plot_seasonality(m, name, ax=None, uncertainty=True, figsize=(10, 6), ):
     end = start + pd.Timedelta(days=period)
     plot_points = 200
     days = pd.to_datetime(np.linspace(start.value, end.value, plot_points))
-    df_y = seasonality_plot_df(m, days, xlabel=m.date_col)
+    df_y = seasonality_plot_df(m, days)
     seas = m.predict_seasonal_components(df_y)
     artists += ax.plot(df_y[m.date_col].dt.to_pydatetime(), seas[name], ls='-',
                         c='#0072B2')
@@ -953,7 +954,7 @@ def get_seasonality_plotly_props(m, name, uncertainty=True, ):
     else:  # Minute Precision
         plot_points = np.floor(period * 24 * 60).astype(int)
     days = pd.to_datetime(np.linspace(start.value, end.value, plot_points, endpoint=False))
-    df_y = seasonality_plot_df(m, days, xlabel=m.date_col)
+    df_y = seasonality_plot_df(m, days )
     seas = m.predict_seasonal_components(df_y)
 
     traces = []


### PR DESCRIPTION
I opened an issue for this as well to track https://github.com/facebook/prophet/issues/1737

I noticed that when calling the .fit function we must have the columns named as `ds` and `y`. In my use that meaned I had to mutate my Dataframe in order to use this library. So I allowed an optional attribute with the name of `date_col` and `y_col` to allow the user to input the name of the columns they want to use. 

This makes it so users don't have to mutate the column names of their Dataframe. If there are any changes to be made feel free to leave a comment. Also if this feature is not needed/wanted feel free to close this PR as well

Still need to add tests to this PR and here is a snippet showing how it works

<img width="841" alt="Screen Shot 2020-11-14 at 2 49 17 PM" src="https://user-images.githubusercontent.com/15950706/99156701-990b6280-2688-11eb-8421-54c0817a04f5.png">

Notice how we can pick out the columns we want to use vs having to rename to `ds` and `y`

Thanks,
Kevin