### PR TITLE
The README file in this repo has a bad link - [404:NotFound] - MIT License

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,4 +135,4 @@ Make sure compilers (gcc, g++, build-essential) and Python development tools (py
 
 ## License
 
-Prophet is licensed under the [MIT license](LICENSE.md).
+Prophet is licensed under the [MIT license](LICENSE).


### PR DESCRIPTION

The markup version of the readme that is displayed for the main page in this repo contains the following bad link:

"MIT License"
Status code [404:NotFound] - Link: https://github.com/facebook/prophet/blob/master/LICENSE.md

It should be - https://github.com/facebook/prophet/blob/master/LICENSE

**Extra**

This bad link was found by a tool I recently created as part of an new experimental hobby project: https://github.com/MrCull/GitHub-Repo-ReadMe-Dead-Link-Finder

Re-check this Repo using the tool’s website: http://githubreadmechecker.com/Home/Search?SingleRepoUri=https%3a%2f%2fgithub.com%2ffacebook%2fprophet

If you have any feedback on the tool itself, or the information provided here, then please feel free to share your thoughts by adding a comment here, or adding a “Discussions” comment in the tool’s Repo.