### PR TITLE
used regex to format the `name` variable for plotting holiday components

### DIFF
--- a/R/R/plot.R
+++ b/R/R/plot.R
@@ -177,11 +177,17 @@ prophet_plot_components <- function(
 plot_forecast_component <- function(
   m, fcst, name, uncertainty = TRUE, plot_cap = FALSE
 ) {
-  formatted.name <- gsub("'|\"", "", name)
-  formatted.name <- gsub("\\s+", "_", formatted.name)
+
+  wrapped.name <- paste0("`", name, "`")
+  
+  lower.name <- paste0(name, '_lower')
+  lower.name <- paste0("`", lower.name, "`")
+
+  upper.name <- paste0(name, '_upper')
+  upper.name <- paste0("`", upper.name, "`")
 
   gg.comp <- ggplot2::ggplot(
-      fcst, ggplot2::aes_string(x = 'ds', y = formatted.name, group = 1)) +
+      fcst, ggplot2::aes_string(x = 'ds', y = wrapped.name, group = 1)) +
     ggplot2::geom_line(color = "#0072B2", na.rm = TRUE)
   if (exists('cap', where = fcst) && plot_cap) {
     gg.comp <- gg.comp + ggplot2::geom_line(
@@ -195,7 +201,7 @@ plot_forecast_component <- function(
     gg.comp <- gg.comp +
       ggplot2::geom_ribbon(
         ggplot2::aes_string(
-          ymin = paste0(formatted.name, '_lower'), ymax = paste0(formatted.name, '_upper')
+          ymin = lower.name, ymax = upper.name
         ),
         alpha = 0.2,
         fill = "#0072B2",

--- a/R/R/plot.R
+++ b/R/R/plot.R
@@ -177,8 +177,11 @@ prophet_plot_components <- function(
 plot_forecast_component <- function(
   m, fcst, name, uncertainty = TRUE, plot_cap = FALSE
 ) {
+  formatted.name <- gsub("'|\"", "", name)
+  formatted.name <- gsub("\\s+", "_", formatted.name)
+
   gg.comp <- ggplot2::ggplot(
-      fcst, ggplot2::aes_string(x = 'ds', y = name, group = 1)) +
+      fcst, ggplot2::aes_string(x = 'ds', y = formatted.name, group = 1)) +
     ggplot2::geom_line(color = "#0072B2", na.rm = TRUE)
   if (exists('cap', where = fcst) && plot_cap) {
     gg.comp <- gg.comp + ggplot2::geom_line(
@@ -192,7 +195,7 @@ plot_forecast_component <- function(
     gg.comp <- gg.comp +
       ggplot2::geom_ribbon(
         ggplot2::aes_string(
-          ymin = paste0(name, '_lower'), ymax = paste0(name, '_upper')
+          ymin = paste0(formatted.name, '_lower'), ymax = paste0(formatted.name, '_upper')
         ),
         alpha = 0.2,
         fill = "#0072B2",


### PR DESCRIPTION
fixes issue/bug   #1696 

Removes all single quotes (') and double quotes (") in the `name` variable
AND replaces all whitespace with an underscore (_). Now, `ggplot2::aes_string()` can handle a column
name like the holiday `New Year's Day`.