### PR TITLE
Corrected License Link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,4 +135,4 @@ Make sure compilers (gcc, g++, build-essential) and Python development tools (py
 
 ## License
 
-Prophet is licensed under the [MIT license](LICENSE.md).
+Prophet is licensed under the [MIT license](LICENSE).


### PR DESCRIPTION
THe MIT License link at the end of the README.md file opens a 404 error page. 
The link has '.md' at the end while the LICENSE file does not have the .md extension.
I fixed the link by removing the .md in the end.