### PR TITLE
updated readme with link to Contributing Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Prophet is [open source software](https://code.facebook.com/projects/) released 
 - HTML documentation: https://facebook.github.io/prophet/docs/quick_start.html
 - Issue tracker: https://github.com/facebook/prophet/issues
 - Source code repository: https://github.com/facebook/prophet
+- Contributing: https://facebook.github.io/prophet/docs/contributing.html
 - Prophet R package: https://cran.r-project.org/package=prophet
 - Prophet Python package: https://pypi.python.org/pypi/fbprophet/
 - Release blogpost: https://research.fb.com/prophet-forecasting-at-scale/


### PR DESCRIPTION
When I wanted to contribute to the code base I found it pretty difficult to find this link: https://facebook.github.io/prophet/docs/contributing.html

Pretty much anyone who wants to contribute will need to go through this guide to do things like: generate documentation, build, run tests, etc. I don't think that this guide is mentioned anywhere on this Github repo and I think it would help people out a lot to be able to find it quickly. 

So, I added a link to this page to the `Important links` section of the `README.md`
    