### PR TITLE
Install fbprophet package instead of prophet

### DIFF
--- a/docs/_docs/installation.md
+++ b/docs/_docs/installation.md
@@ -57,4 +57,4 @@ Make sure compilers (gcc, g++, build-essential) and Python development tools (py
 
 ### Anaconda
 
-Use `conda install gcc` to set up gcc. The easiest way to install Prophet is through conda-forge: `conda install -c conda-forge prophet`.
+Use `conda install gcc` to set up gcc. The easiest way to install Prophet is through conda-forge: `conda install -c conda-forge fbprophet`.


### PR DESCRIPTION
The `prophet` package does not seem to exist on conda-forge. Instead, the `fbprophet` package seems to be available.