### PR TITLE
added argument for point color to cv plot

### DIFF
--- a/python/prophet/plot.py
+++ b/python/prophet/plot.py
@@ -473,7 +473,8 @@ def add_changepoints_to_plot(
 
 
 def plot_cross_validation_metric(
-    df_cv, metric, rolling_window=0.1, ax=None, figsize=(10, 6), color='b'
+    df_cv, metric, rolling_window=0.1, ax=None, figsize=(10, 6), color='b',
+    point_color='gray'
 ):
     """Plot a performance metric vs. forecast horizon from cross validation.
 
@@ -543,7 +544,7 @@ def plot_cross_validation_metric(
     x_plt = df_none['horizon'].astype('timedelta64[ns]').astype(np.int64) / float(dt_conversions[i])
     x_plt_h = df_h['horizon'].astype('timedelta64[ns]').astype(np.int64) / float(dt_conversions[i])
 
-    ax.plot(x_plt, df_none[metric], '.', alpha=0.1, c=color)
+    ax.plot(x_plt, df_none[metric], '.', alpha=0.1, c=point_color)
     ax.plot(x_plt_h, df_h[metric], '-', c=color)
     ax.grid(True)
 


### PR DESCRIPTION
This PR fixes https://github.com/facebook/prophet/issues/1894. 

Current behavior:
```
fig = plot_cross_validation_metric(df_cv1, metric='mae', color='b')
plot_cross_validation_metric(df_cv2, metric='mae', ax=fig.gca(), color='r')
plot_cross_validation_metric(df_cv3, metric='mae', ax=fig.gca(), color='y')
plot_cross_validation_metric(df_cv4, metric='mae', ax=fig.gca(), color='g')
plt.ylim(0, 500)
plt.show()
```
![image](https://user-images.githubusercontent.com/20135094/116826234-db95fe00-ab47-11eb-8ac1-1f71e817f636.png)

This PR allows the following alternative behavior:
```
fig = plot_cross_validation_metric(df_cv1, metric='mae', color='b')
plot_cross_validation_metric(df_cv2, metric='mae', ax=fig.gca(), color='r')
plot_cross_validation_metric(df_cv3, metric='mae', ax=fig.gca(), color='y')
plot_cross_validation_metric(df_cv4, metric='mae', ax=fig.gca(), color='g')
plt.ylim(0, 500)
plt.show()
```
![image](https://user-images.githubusercontent.com/20135094/116826254-f7010900-ab47-11eb-85f2-26a5d82f48d9.png)


```
fig = plot_cross_validation_metric(df_cv1, metric='mae', color='b')
plot_cross_validation_metric(df_cv2, metric='mae', ax=fig.gca(), color='r', point_color='None')
plot_cross_validation_metric(df_cv3, metric='mae', ax=fig.gca(), color='y', point_color='None')
plot_cross_validation_metric(df_cv4, metric='mae', ax=fig.gca(), color='g', point_color='None')
plt.ylim(0, 500)
plt.show()
```
![image](https://user-images.githubusercontent.com/20135094/116826264-fd8f8080-ab47-11eb-8e4d-92ca8170b572.png)

Current behavior is retained with:
```
fig = plot_cross_validation_metric(df_cv1, metric='mae', color='b', point_color='b')
plot_cross_validation_metric(df_cv2, metric='mae', ax=fig.gca(), color='r', point_color='r')
plot_cross_validation_metric(df_cv3, metric='mae', ax=fig.gca(), color='y', point_color='y')
plot_cross_validation_metric(df_cv4, metric='mae', ax=fig.gca(), color='g', point_color='g')
plt.ylim(0, 500)
plt.show()
```
