### PR TITLE
Fix R CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -78,6 +78,7 @@ jobs:
       run: |
         remotes::install_deps(pkgdir = "R/", dependencies = NA)
         remotes::install_cran("rcmdcheck")
+        install.packages(c("cmdstanr", "posterior"), repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
       shell: Rscript {0}
     - name: Check
       env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,6 @@ jobs:
   build-and-test-r:
 
     runs-on: ${{ matrix.config.os }}
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
     strategy:
       matrix:
         config:
@@ -78,6 +77,8 @@ jobs:
     - name: Install dependencies
       run: |
         remotes::install_deps(pkgdir = "R/", dependencies = TRUE)
+        remove.packages("rstantools")
+        remotes::install_version("rstantools", "2.0.0")
         remotes::install_cran("rcmdcheck")
       shell: Rscript {0}
     - name: Check

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -76,9 +76,7 @@ jobs:
         done < <(Rscript -e 'writeLines(remotes::system_requirements(os = "ubuntu", os_release = "20.04", path = "R/"))')
     - name: Install dependencies
       run: |
-        remotes::install_deps(pkgdir = "R/", dependencies = TRUE)
-        remove.packages("rstantools")
-        remotes::install_version("rstantools", "2.0.0")
+        remotes::install_deps(pkgdir = "R/", dependencies = NA)
         remotes::install_cran("rcmdcheck")
       shell: Rscript {0}
     - name: Check

--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -41,8 +41,6 @@ Suggests:
     testthat,
     readr,
     rmarkdown
-Additional_repositories:
-    https://mc-stan.org/r-packages/
 SystemRequirements: GNU make, C++11
 Biarch: true
 License: MIT + file LICENSE


### PR DESCRIPTION
R CI has been failing with:

```
make: *** [/opt/R/4.0.5/lib/R/etc/Makeconf:179: stanExports_prophet.o] Error 1
ERROR: compilation failed for package ‘prophet’
* removing ‘/tmp/RtmpelX00l/Rinst2f892074a317/prophet’
      -----------------------------------
ERROR: package installation failed
```

Because we've specified `mc-stan.org` in `Additional_repositories`, `remotes::install_deps()` looks there and finds an updated version of rstan that hasn't been tested against prophet yet:

```
trying URL 'https://mc-stan.org/r-packages/src/contrib/StanHeaders_2.26.1.tar.gz'
Content type 'application/gzip' length 1765579 bytes (1.7 MB)
==================================================
downloaded 1.7 MB

trying URL 'https://mc-stan.org/r-packages/src/contrib/cmdstanr_0.4.0.tar.gz'
Content type 'application/gzip' length 195914 bytes (191 KB)
==================================================
downloaded 191 KB

trying URL 'https://mc-stan.org/r-packages/src/contrib/rstan_2.26.1.tar.gz'
Content type 'application/gzip' length 1035239 bytes (1010 KB)
```

We remove `mc-stan.org` from `Additional_repositories` and install `cmdstanr` and `posterior` manually for CI.