### PR TITLE
add setup_requires on pystan so build requirements are in the metadata

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -129,7 +129,7 @@ setup(
     author_email='sjtz@pm.me',
     license='MIT',
     packages=find_packages(),
-    setup_requires=[
+    setup_requires=['pystan~=2.19.1.1'
     ],
     install_requires=install_requires,
     python_requires='>=3',


### PR DESCRIPTION
It seems that pystan is a build time requirement (since it is used in the `from prophet.models import StanBackendEnum` import in `build_models`). It seems however, that it isn't listed in the `setup_requires` so that the installing system doesn't know that it is a build requirement.

This PR adds the needed pystan build requirement.