### PR TITLE
Add drop = FALSE in regressor_coefficients()

### DIFF
--- a/R/R/utilities.R
+++ b/R/R/utilities.R
@@ -38,7 +38,7 @@ regressor_coefficients <- function(m){
   regr_mus <- unlist(lapply(m$extra_regressors, function (x) x$mu))
   regr_stds <- unlist(lapply(m$extra_regressors, function(x) x$std))
 
-  beta_indices <- which(m$train.component.cols[, regr_names] == 1, arr.ind = TRUE)[, "row"]
+  beta_indices <- which(m$train.component.cols[, regr_names, drop = FALSE] == 1, arr.ind = TRUE)[, "row"]
   betas <- m$params$beta[, beta_indices, drop = FALSE]
   # If regressor is additive, multiply by the scale factor to put coefficients on the original training data scale.
   y_scale_indicator <- matrix(


### PR DESCRIPTION
Add `drop = FALSE` in the definition of `regressor_coefficients()` to handle the case when there is only one additional regressor. Without `drop = FALSE`, if there is only one additional regressor, the `regressor_coefficients()` function produces an error.

Example:

```
library(prophet)

set.seed(1)

history <- data.frame(ds = seq(as.Date('2015-01-01'), as.Date('2016-01-01'), by ='d'),
                      y = sin(1:366/200) + rnorm(366)/10)

history$x1 <- rnorm(nrow(history))
history$x2 <- rnorm(nrow(history))

m1 <- prophet()
m2 <- prophet()

m1 <- add_regressor(m1, "x1")

m2 <- add_regressor(m2, "x1")
m2 <- add_regressor(m2, "x2")

m1 <- fit.prophet(m1, history)
m2 <- fit.prophet(m2, history)

regressor_coefficients(m2)

##   regressor regressor_mode       center   coef_lower         coef   coef_upper
## 1        x1       additive -0.071847276 -0.003070719 -0.003070719 -0.003070719
## 2        x2       additive -0.001956119  0.001188227  0.001188227  0.001188227

regressor_coefficients(m1)

## Error in which(m$train.component.cols[, regr_names] == 1, arr.ind = TRUE)[,  :
##   incorrect number of dimensions

# After adding `drop = FALSE` to
# `beta_indices <- which(m$train.component.cols[, regr_names] == 1, arr.ind = TRUE)[, "row"]`:

regressor_coefficients(m1)

##   regressor regressor_mode      center   coef_lower         coef   coef_upper
## 1        x1       additive -0.07184728 -0.003040683 -0.003040683 -0.003040683

sessionInfo()

## R version 4.0.3 (2020-10-10)
## Platform: x86_64-w64-mingw32/x64 (64-bit)
## Running under: Windows 10 x64 (build 19042)

## Matrix products: default

## locale:
## [1] LC_COLLATE=English_Australia.1252  LC_CTYPE=English_Australia.1252   
## [3] LC_MONETARY=English_Australia.1252 LC_NUMERIC=C                      
## [5] LC_TIME=English_Australia.1252    

## attached base packages:
## [1] stats     graphics  grDevices utils     datasets  methods   base     

## other attached packages:
## [1] prophet_1.0  rlang_0.4.11 Rcpp_1.0.6  

## loaded via a namespace (and not attached):
##  [1] pillar_1.6.1         compiler_4.0.3       prettyunits_1.1.1    pkgbuild_1.2.0      
##  [5] gtable_0.3.0         lubridate_1.7.10     jsonlite_1.7.2       lifecycle_1.0.0     
##  [9] tibble_3.1.2         pkgconfig_2.0.3      DBI_1.1.1            cli_2.5.0           
## [13] parallel_4.0.3       curl_4.3.1           loo_2.4.1            gridExtra_2.3       
## [17] withr_2.4.2          dplyr_1.0.6          generics_0.1.0       vctrs_0.3.8         
## [21] grid_4.0.3           stats4_4.0.3         tidyselect_1.1.1     glue_1.4.2          
## [25] inline_0.3.18        R6_2.5.0             processx_3.5.2       fansi_0.4.2         
## [29] rstan_2.21.2         ggplot2_3.3.3        tidyr_1.1.3          purrr_0.3.4         
## [33] callr_3.7.0          magrittr_2.0.1       matrixStats_0.58.0   scales_1.1.1        
## [37] codetools_0.2-18     ps_1.6.0             ellipsis_0.3.2       StanHeaders_2.21.0-7
## [41] assertthat_0.2.1     colorspace_2.0-1     V8_3.4.2             utf8_1.2.1          
## [45] munsell_0.5.0        RcppParallel_5.1.4   crayon_1.4.1
```

Thanks for the prophet package. I'm not very familiar with GitHub so if I've done anything wrong, please let me know.