### PR TITLE
Speed up make_holiday_features by up to 35%

### DIFF
--- a/python/prophet/forecaster.py
+++ b/python/prophet/forecaster.py
@@ -534,17 +534,17 @@ class Prophet(object):
         prior_scales = {}
         # Makes an index so we can perform `get_loc` below.
         # Strip to just dates.
-        row_index = pd.DatetimeIndex(dates.apply(lambda x: x.date()))
+        row_index = pd.DatetimeIndex(dates.dt.date)
 
-        for _ix, row in holidays.iterrows():
+        for row in holidays.itertuples():
             dt = row.ds.date()
             try:
-                lw = int(row.get('lower_window', 0))
-                uw = int(row.get('upper_window', 0))
+                lw = int(getattr(row, 'lower_window', 0))
+                uw = int(getattr(row, 'upper_window', 0))
             except ValueError:
                 lw = 0
                 uw = 0
-            ps = float(row.get('prior_scale', self.holidays_prior_scale))
+            ps = float(getattr(row, 'prior_scale', self.holidays_prior_scale))
             if np.isnan(ps):
                 ps = float(self.holidays_prior_scale)
             if row.holiday in prior_scales and prior_scales[row.holiday] != ps:

--- a/python/scripts/generate_holidays_file.py
+++ b/python/scripts/generate_holidays_file.py
@@ -61,7 +61,7 @@ def generate_holidays_file():
         all_holidays.append(df)
 
     generated_holidays = pd.concat(all_holidays, axis=0, ignore_index=True)
-    generated_holidays['year'] = generated_holidays.ds.apply(lambda x: x.year)
+    generated_holidays['year'] = generated_holidays.ds.dt.year
     generated_holidays.sort_values(['country', 'ds', 'holiday'], inplace=True)
 
     # Convert to ASCII, and drop holidays that fail to convert


### PR DESCRIPTION
First, thank you for this awesome library! While looking through it, I noticed some potential performance improvements relating to how pandas is used.

To demonstrate the improvements:
```python
In [3]: holidays
Out[3]: 
     0  2012-06-06              seans-bday  0.0  1.0
0    1  2013-06-06              seans-bday  0.0  1.0
1    2  2012-01-01            NewYear'sDay  NaN  NaN
2    3  2012-01-02  NewYear'sDay(Observed)  NaN  NaN
3    4  2012-01-16  MartinLutherKingJr.Day  NaN  NaN
4    5  2012-02-20    Washington'sBirthday  NaN  NaN
5    6  2012-05-28             MemorialDay  NaN  NaN
6    7  2012-07-04         IndependenceDay  NaN  NaN
7    8  2012-09-03                LaborDay  NaN  NaN
8    9  2012-10-08             ColumbusDay  NaN  NaN
9   10  2012-11-11             VeteransDay  NaN  NaN
10  11  2012-11-12   VeteransDay(Observed)  NaN  NaN
11  12  2012-11-22            Thanksgiving  NaN  NaN
12  13  2012-12-25            ChristmasDay  NaN  NaN
13  14  2013-01-01            NewYear'sDay  NaN  NaN
14  15  2013-01-21  MartinLutherKingJr.Day  NaN  NaN
15  16  2013-02-18    Washington'sBirthday  NaN  NaN
16  17  2013-05-27             MemorialDay  NaN  NaN
17  18  2013-07-04         IndependenceDay  NaN  NaN
18  19  2013-09-02                LaborDay  NaN  NaN
19  20  2013-10-14             ColumbusDay  NaN  NaN
20  21  2013-11-11             VeteransDay  NaN  NaN
21  22  2013-11-28            Thanksgiving  NaN  NaN
22  23  2013-12-25            ChristmasDay  NaN  NaN
23  24  2014-01-01            NewYear'sDay  NaN  NaN
24  25  2014-01-20  MartinLutherKingJr.Day  NaN  NaN
25  26  2014-02-17    Washington'sBirthday  NaN  NaN
26  27  2014-05-26             MemorialDay  NaN  NaN
27  28  2014-07-04         IndependenceDay  NaN  NaN
28  29  2014-09-01                LaborDay  NaN  NaN
29  30  2014-10-13             ColumbusDay  NaN  NaN
30  31  2014-11-11             VeteransDay  NaN  NaN
31  32  2014-11-27            Thanksgiving  NaN  NaN
32  33  2014-12-25            ChristmasDay  NaN  NaN

In [4]: %%timeit
   ...: for idx, row in holidays.iterrows(): pass
   ...: 
   ...: 
2.44 ms ± 20.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [5]: %%timeit
   ...: for row in holidays.itertuples(): pass
   ...: 
   ...: 
417 µs ± 3.46 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

```python
In [7]: dates
Out[7]: 
0     2012-05-18
1     2012-05-21
2     2012-05-22
3     2012-05-23
4     2012-05-24
         ...    
505   2014-05-23
506   2014-05-27
507   2014-05-28
508   2014-05-29
509   2014-05-30
Name: ds, Length: 510, dtype: datetime64[ns]

In [8]: %%timeit
   ...: pd.DatetimeIndex(dates.apply(lambda x: x.date()))
   ...: 
   ...: 
2.17 ms ± 49 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [9]: %%timeit
   ...: pd.DatetimeIndex(dates.dt.date)
   ...: 
   ...: 
334 µs ± 10.2 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

```

----

To demonstrate using the setup of the `test_custom_seasonality` test:

On master:
```python
In [3]: %%timeit
   ...: m.make_holiday_features(m.history['ds'], holidays)
   ...: 
   ...: 
2.79 ms ± 140 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

```

On this branch:
```python
In [2]: %%timeit
   ...: m.make_holiday_features(m.history['ds'], holidays)
   ...: 
   ...: 
1.79 ms ± 28.3 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```