### PR TITLE
minor fixing :  typo grammar

### DIFF
--- a/R/R/prophet.R
+++ b/R/R/prophet.R
@@ -300,7 +300,7 @@ time_diff <- function(ds1, ds2, units = "days") {
 
 #' Prepare dataframe for fitting or predicting.
 #'
-#' Adds a time index and scales y. Creates auxillary columns 't', 't_ix',
+#' Adds a time index and scales y. Creates auxiliary columns 't', 't_ix',
 #' 'y_scaled', and 'cap_scaled'. These columns are used during both fitting
 #' and predicting.
 #'
@@ -816,7 +816,7 @@ add_country_holidays <- function(m, country_name) {
 #'
 #' @return List with items
 #'  seasonal.features: Dataframe with regressor features,
-#'  prior.scales: Array of prior scales for each colum of the features
+#'  prior.scales: Array of prior scales for each column of the features
 #'    dataframe.
 #'  component.cols: Dataframe with indicators for which regression components
 #'    correspond to which columns.
@@ -1648,7 +1648,7 @@ sample_predictive_trend <- function(model, df, iteration) {
 #' @export
 make_future_dataframe <- function(m, periods, freq = 'day',
                                   include_history = TRUE) {
-  # For backwards compatability with previous zoo date type,
+  # For backwards compatibility with previous zoo date type,
   if (freq == 'm') {
     freq <- 'month'
   }

--- a/R/man/make_all_seasonality_features.Rd
+++ b/R/man/make_all_seasonality_features.Rd
@@ -16,7 +16,7 @@ added regressors.}
 \value{
 List with items
  seasonal.features: Dataframe with regressor features,
- prior.scales: Array of prior scales for each colum of the features
+ prior.scales: Array of prior scales for each column of the features
    dataframe.
  component.cols: Dataframe with indicators for which regression components
    correspond to which columns.

--- a/R/man/setup_dataframe.Rd
+++ b/R/man/setup_dataframe.Rd
@@ -18,7 +18,7 @@ specified additional regressors must also be present.}
 list with items 'df' and 'm'.
 }
 \description{
-Adds a time index and scales y. Creates auxillary columns 't', 't_ix',
+Adds a time index and scales y. Creates auxiliary columns 't', 't_ix',
 'y_scaled', and 'cap_scaled'. These columns are used during both fitting
 and predicting.
 }

--- a/docs/_docs/multiplicative_seasonality.md
+++ b/docs/_docs/multiplicative_seasonality.md
@@ -68,7 +68,7 @@ fig = m.plot_components(forecast)
 ![png](/prophet/static/multiplicative_seasonality_files/multiplicative_seasonality_10_0.png) 
 
 
-With `seasonality_mode='multiplicative'`, holiday effects will also be modeled as multiplicative. Any added seasonalities or extra regressors will by default use whatever `seasonality_mode` is set to, but can be overriden by specifying `mode='additive'` or `mode='multiplicative'` as an argument when adding the seasonality or regressor.
+With `seasonality_mode='multiplicative'`, holiday effects will also be modeled as multiplicative. Any added seasonalities or extra regressors will by default use whatever `seasonality_mode` is set to, but can be overridden by specifying `mode='additive'` or `mode='multiplicative'` as an argument when adding the seasonality or regressor.
 
 
 

--- a/python/prophet/diagnostics.py
+++ b/python/prophet/diagnostics.py
@@ -170,7 +170,7 @@ def cross_validation(model, horizon, period=None, initial=None, parallel=None, c
             try:
                 from dask.distributed import get_client
             except ImportError as e:
-                raise ImportError("parallel='dask' requies the optional "
+                raise ImportError("parallel='dask' requires the optional "
                                   "dependency dask.") from e
             pool = get_client()
             # delay df and model to avoid large objects in task graph.


### PR DESCRIPTION
fix typo grammar on separate files on ```prophet```, replace to correct word with reference from [Merriam webster](https://www.merriam-webster.com/)