### PR TITLE
Fix R CI - install Suggests packages explicitly

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Install dependencies
       run: |
         remotes::install_deps(pkgdir = "R/", dependencies = NA)
-        remotes::install_cran("rcmdcheck")
+        remotes::install_cran(c("rcmdcheck", "knitr", "testthat", "readr", "rmarkdown"))
         install.packages(c("cmdstanr", "posterior"), repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
       shell: Rscript {0}
     - name: Check


### PR DESCRIPTION
Not quite sure what happened last time / why we didn't pick this up, but seems we should be installing all of the `Suggests` package explicitly -- we were only installing `cmdstanr` and `posterior` until now.

This should hopefully fix this error: https://github.com/facebook/prophet/runs/3329042348?check_suite_focus=true