### PR TITLE
Speed up Linux wheel building and other fixes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,6 +19,12 @@ jobs:
       fail-fast: false
 
     steps:
+    - name: "Get OS version (Linux)"
+      if: startsWith(runner.os, 'Linux')
+      run: |
+        echo "OS_VERSION=`lsb_release -sr`" >> $GITHUB_ENV
+        echo "PIP_DEFAULT_CACHE=$HOME/.cache/pip" >> $GITHUB_ENV
+        echo "DEFAULT_HOME=$HOME" >> $GITHUB_ENV
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
@@ -28,7 +34,7 @@ jobs:
       id: cache-pip
       uses: actions/cache@v2
       with:
-        path: $HOME/.cache/pip
+        path: ${{ env.PIP_DEFAULT_CACHE }}
         key: ${{ runner.os }}-pip-${{ hashFiles('**/python/requirements.txt') }}-v1
         restore-keys: |
           ${{ runner.os }}-pip-
@@ -36,7 +42,7 @@ jobs:
       id: cache-cmdstan
       uses: actions/cache@v2
       with:
-        path: $HOME/.cmdstan
+        path: ${{ env.DEFAULT_HOME }}/.cmdstan
         key: ${{ runner.os }}-cmdstan-${{ env.CMDSTAN_VERSION }}-v1
     - name: "Download cmdstan"
       if: steps.cache-cmdstan.outputs.cache-hit != 'true'

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -94,7 +94,7 @@ jobs:
             HOME="/host/${{ env.DEFAULT_HOME }}"
             PIP_CACHE_DIR="/host/${{ env.PIP_DEFAULT_CACHE }}"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_BEFORE_ALL_LINUX: sudo chmod -R a+rwx $PIP_CACHE_DIR
+          CIBW_BEFORE_ALL_LINUX: sudo chmod -R a+rwx /host/${{ env.PIP_DEFAULT_CACHE }}
           CIBW_ARCHS: native
           CIBW_BUILD_FRONTEND: build
           CIBW_TEST_REQUIRES: pytest

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -15,15 +15,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:
-          - "macos-latest"
-          - "ubuntu-latest"
-        python-version:
-          - "3.6"
-          - "3.7"
-          - "3.8"
-        architecture:
-          - x64
+        os: ["macos-latest", "ubuntu-latest"]
+        python-version: [3.6, 3.7, 3.8]
+        architecture: ["x64"]
+        include:
+          - python-version: 3.6
+            CIBW_BUILD: cp36-*
+          - python-version: 3.7
+            CIBW_BUILD: cp37-*
+          - python-version: 3.8
+            CIBW_BUILD: cp38-*
 
       fail-fast: false
 
@@ -87,13 +88,13 @@ jobs:
             STAN_BACKEND="${{ env.STAN_BACKEND }}"
             CMDSTAN_VERSION=${{ env.CMDSTAN_VERSION }}
           # Linux builds run in a Docker container, need to point the cache to the host machine.
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_ENVIRONMENT_LINUX: >
             STAN_BACKEND="${{ env.STAN_BACKEND }}"
             CMDSTAN_VERSION=${{ env.CMDSTAN_VERSION }}
             HOME="/host/${{ env.DEFAULT_HOME }}"
             PIP_CACHE_DIR="/host/${{ env.PIP_DEFAULT_CACHE }}"
-          CIBW_BEFORE_ALL_LINUX: sudo chmod -R a+rwx ${{ env.PIP_DEFAULT_CACHE }}
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_BEFORE_ALL_LINUX: sudo chmod -R a+rwx $PIP_CACHE_DIR
           CIBW_ARCHS: native
           CIBW_BUILD_FRONTEND: build
           CIBW_TEST_REQUIRES: pytest

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -16,15 +16,8 @@ jobs:
     strategy:
       matrix:
         os: ["macos-latest", "ubuntu-latest"]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8]
         architecture: ["x64"]
-        include:
-          - python-version: 3.6
-            CIBW_BUILD: cp36-*
-          - python-version: 3.7
-            CIBW_BUILD: cp37-*
-          - python-version: 3.8
-            CIBW_BUILD: cp38-*
 
       fail-fast: false
 
@@ -95,6 +88,7 @@ jobs:
             PIP_CACHE_DIR="/host/${{ env.PIP_DEFAULT_CACHE }}"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_BEFORE_ALL_LINUX: chmod -R a+rwx /host/${{ env.PIP_DEFAULT_CACHE }}
+          CIBW_BUILD: cp36-* cp37-* cp38-*
           CIBW_ARCHS: native
           CIBW_BUILD_FRONTEND: build
           CIBW_TEST_REQUIRES: pytest

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -94,7 +94,7 @@ jobs:
             HOME="/host/${{ env.DEFAULT_HOME }}"
             PIP_CACHE_DIR="/host/${{ env.PIP_DEFAULT_CACHE }}"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_BEFORE_ALL_LINUX: sudo chmod -R a+rwx /host/${{ env.PIP_DEFAULT_CACHE }}
+          CIBW_BEFORE_ALL_LINUX: chmod -R a+rwx /host/${{ env.PIP_DEFAULT_CACHE }}
           CIBW_ARCHS: native
           CIBW_BUILD_FRONTEND: build
           CIBW_TEST_REQUIRES: pytest


### PR DESCRIPTION
### Changes

* Use `manylinux2014` images, to prevent building the wheel for `pandas`.
* Properly give the docker container access to the `pip` cache on Linux, to speed up dependency installation

### Testing

- [x] CI checks pass
- [x] [Manual wheel builds](https://github.com/facebook/prophet/actions/runs/1299679630) pass 
