### PR TITLE
Typo inthe Contributing Markdown File. 

### DIFF
--- a/docs/_docs/contributing.md
+++ b/docs/_docs/contributing.md
@@ -158,7 +158,7 @@ Prophet uses the ``unittest`` package for running tests in Python and ``testthat
 
 The entire test suite can be run by typing:
 ```bash
-$ python setup.py tests
+$ python setup.py test
 ```
 
 ### R


### PR DESCRIPTION
There was a typo in the documentation. When one wants to run tests. Instead of "test", the documentation said "tests",  which is not the right command, and caused confusion for me.