### PR TITLE
docs: adding ELI5 video to the home page

### DIFF
--- a/docs/css/main.scss
+++ b/docs/css/main.scss
@@ -147,3 +147,7 @@ h5:hover .header-link,
 h6:hover .header-link {
   opacity: 1;
 }
+
+.videoBlock {
+	text-align: center;
+  }

--- a/docs/css/main.scss
+++ b/docs/css/main.scss
@@ -149,5 +149,5 @@ h6:hover .header-link {
 }
 
 .videoBlock {
-	text-align: center;
-  }
+  text-align: center;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,11 @@ layout: home
 title: Prophet
 id: home
 ---
+## Watch Introductory Video
+
+<div class="videoBlock">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/eJrbKU09h-0" title="Explain Like I'm 5: Prophet" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen ></iframe>
+</div>
 
 Prophet is a procedure for forecasting time series data based on an additive model where non-linear trends are fit with yearly, weekly, and daily seasonality, plus holiday effects. It works best with time series that have strong seasonal effects and several seasons of historical data. Prophet is robust to missing data and shifts in the trend, and typically handles outliers well.
 


### PR DESCRIPTION
## Summary
Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Docusaurus home page](https://docusaurus.io/), [Jest](https://jestjs.io/), [Litho](https://fblitho.com/), [Hydra](https://hydra.cc/), etc.

## Test plan
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/12485205/155186498-3a9c7580-76c4-4514-865a-80e88e4a1393.png">
