### PR TITLE
adding no history error handling to cross_validation

### DIFF
--- a/python/prophet/diagnostics.py
+++ b/python/prophet/diagnostics.py
@@ -114,7 +114,10 @@ def cross_validation(model, horizon, period=None, initial=None, parallel=None, c
     -------
     A pd.DataFrame with the forecast, actual value and cutoff.
     """
-
+    
+    if model.history is None:
+        raise Exception('Model has not been fit. Fitting the model provides contextual parameters for cross validation.')
+    
     df = model.history.copy().reset_index(drop=True)
     horizon = pd.Timedelta(horizon)
 


### PR DESCRIPTION
This is in response to #2132. I mimicked the history checking style from the `.predict()` method:

https://github.com/facebook/prophet/blob/f16c782661c33440331205d5f6455995e3a037f8/python/prophet/forecaster.py#L1197-L1198

I'm very much open to changing the language. This first stab was to raise a useful error and to try and explain very simply why `model` needs to be fit first. [ivanmkc](https://github.com/ivanmkc) makes a good point about the concern for temporal leakage and I think it warrants a discussion.