### PR TITLE
Pandas Deprecation Warnings Fix

### DIFF
--- a/python/prophet/forecaster.py
+++ b/python/prophet/forecaster.py
@@ -893,7 +893,7 @@ class Prophet(object):
         group_cols = new_comp['col'].unique()
         if len(group_cols) > 0:
             new_comp = pd.DataFrame({'col': group_cols, 'component': name})
-            components = components.append(new_comp)
+            components = pd.concat([components, new_comp], axis=0)
         return components
 
     def parse_seasonality_args(self, name, arg, auto_disable, default_order):

--- a/python/prophet/serialize.py
+++ b/python/prophet/serialize.py
@@ -153,7 +153,7 @@ def model_from_dict(model_dict):
                 s = s.dt.tz_localize(None)
             setattr(model, attribute, s)
     for attribute in PD_TIMESTAMP:
-        setattr(model, attribute, pd.Timestamp.utcfromtimestamp(model_dict[attribute]))
+        setattr(model, attribute, pd.Timestamp.fromtimestamp(model_dict[attribute], 'UTC').tz_localize(None))
     for attribute in PD_TIMEDELTA:
         setattr(model, attribute, pd.Timedelta(seconds=model_dict[attribute]))
     for attribute in PD_DATAFRAME:


### PR DESCRIPTION
This is meant as a simple test contribution while I build up to a more serious commit.

Solves the following two warnings in latest pandas while retaining the existing behavior:
```
prophet\python\prophet\forecaster.py:896: FutureWarning: The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.
  components = components.append(new_comp)

\prophet\python\prophet\serialize.py:156: FutureWarning: The behavior of Timestamp.utcfromtimestamp is deprecated, in a future version will return a timezone-aware Timestamp with UTC timezone. To keep the old behavior, use Timestamp.utcfromtimestamp(ts).tz_localize(None). To get the future behavior, use Timestamp.fromtimestamp(ts, 'UTC')
  setattr(model, attribute, pd.Timestamp.utcfromtimestamp(model_dict[attribute]).tz_localize(None))

```