### PR TITLE
wheel.yml: Do not build Python 3.6 wheels

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -69,7 +69,7 @@ jobs:
           CIBW_ENVIRONMENT: >
             STAN_BACKEND="${{ env.STAN_BACKEND }}"
             PIP_CACHE_DIR="${{ env.PIP_DEFAULT_CACHE }}"
-          CIBW_BUILD: cp36-* cp37-* cp38-* cp39-* cp310-*
+          CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
           CIBW_ARCHS: native
           CIBW_BUILD_FRONTEND: build
           # CIBW_REPAIR_WHEEL_COMMAND: delvewheel repair -w {dest_dir} {wheel}
@@ -142,7 +142,7 @@ jobs:
             PIP_CACHE_DIR="/host/${{ env.PIP_DEFAULT_CACHE }}"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_BEFORE_ALL_LINUX: chmod -R a+rwx /host/${{ env.PIP_DEFAULT_CACHE }}
-          CIBW_BUILD: cp36-* cp37-* cp38-* cp39-* cp310-*
+          CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS: native
           CIBW_BUILD_FRONTEND: build


### PR DESCRIPTION
`cmdstanpy >=1.0.1` (requirement introduced https://github.com/facebook/prophet/pull/2148) requires Python >= 3.7: https://github.com/stan-dev/cmdstanpy/releases/tag/v1.0.1

Wheel build test: https://github.com/facebook/prophet/actions/runs/2275140778