### PR TITLE
Only encode to JSON once when serializing a Python model

### DIFF
--- a/docs/_docs/additional_topics.md
+++ b/docs/_docs/additional_topics.md
@@ -36,14 +36,13 @@ In Python, models should not be saved with pickle; the Stan backend attached to 
 
 ```python
 # Python
-import json
 from prophet.serialize import model_to_json, model_from_json
 
 with open('serialized_model.json', 'w') as fout:
-    json.dump(model_to_json(m), fout)  # Save model
+    fout.write(model_to_json(m))  # Save model
 
 with open('serialized_model.json', 'r') as fin:
-    m = model_from_json(json.load(fin))  # Load model
+    m = model_from_json(fin.read())  # Load model
 ```
 The json file will be portable across systems, and deserialization is backwards compatible with older versions of prophet.
 

--- a/notebooks/additional_topics.ipynb
+++ b/notebooks/additional_topics.ipynb
@@ -122,14 +122,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import json\n",
     "from prophet.serialize import model_to_json, model_from_json\n",
     "\n",
     "with open('serialized_model.json', 'w') as fout:\n",
-    "    json.dump(model_to_json(m), fout)  # Save model\n",
+    "    fout.write(model_to_json(m))  # Save model\n",
     "\n",
     "with open('serialized_model.json', 'r') as fin:\n",
-    "    m = model_from_json(json.load(fin))  # Load model"
+    "    m = model_from_json(fin.read())  # Load model"
    ]
   },
   {


### PR DESCRIPTION
Changed documentation to remove suggestion to double-encode JSON when serializing Python models (and the corresponding changes for loading them again).

Closes #2133 