### PR TITLE
Build wheels with native `cibuildwheel`action

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -95,6 +95,7 @@ jobs:
           CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS: native
+          CIBW_BEFORE_ALL: cd python
           CIBW_BUILD_FRONTEND: build
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest --pyargs prophet

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -11,12 +11,11 @@ env:
 
 jobs:
   make-wheel-windows:
-    name: ${{ matrix.architecture }}-${{ matrix.os }}
+    name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: ["windows-latest"]
-        architecture: ["x64"]
       fail-fast: false
 
     steps:
@@ -81,12 +80,11 @@ jobs:
           path: "./**/*.whl"
 
   make-wheels-macos-linux:
-    name: ${{ matrix.architecture }}-${{ matrix.os }}
+    name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: ["macos-latest", "ubuntu-latest"]
-        architecture: ["x64"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -10,81 +10,25 @@ env:
   STAN_BACKEND: "CMDSTANPY"
 
 jobs:
-  make-wheel-windows:
+  make-wheels:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["windows-latest"]
+        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
       fail-fast: false
 
     steps:
-      - name: "Setup environment variables (Windows)"
-        if: startsWith(runner.os, 'Windows')
-        shell: pwsh
-        run: |
-          (Get-ItemProperty "HKLM:System\CurrentControlSet\Control\FileSystem").LongPathsEnabled
-          $os_version = (Get-CimInstance Win32_OperatingSystem).version
-          Echo "OS_VERSION=$os_version" >> $env:GITHUB_ENV
-          Echo "PIP_DEFAULT_CACHE=$HOME/pip/cache" >> $env:GITHUB_ENV
-          Echo "DEFAULT_HOME=$HOME" >> $env:GITHUB_ENV
-
       - name: "Checkout repo"
         uses: actions/checkout@v3
 
-      - name: "Restore pip cache"
-        id: cache-pip
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.PIP_DEFAULT_CACHE }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/python/requirements.txt') }}-v1
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: "Install pip"
-        shell: pwsh
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install cibuildwheel build delvewheel
-
       - name: "Restore RTools40"
+        if: startsWith(runner.os, 'Windows')
         id: cache-rtools
         uses: actions/cache@v2
         with:
           path: C:/rtools40
           key: ${{ runner.os }}-${{ env.OS_VERSION }}-rtools-v1
-
-      - name: "Build wheel"
-        run: |
-          cd python && python -m cibuildwheel --output-dir wheelhouse
-        env:
-          CIBW_ENVIRONMENT: >
-            STAN_BACKEND="${{ env.STAN_BACKEND }}"
-            PIP_CACHE_DIR="${{ env.PIP_DEFAULT_CACHE }}"
-          CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
-          CIBW_ARCHS: native
-          CIBW_BUILD_FRONTEND: build
-          # CIBW_REPAIR_WHEEL_COMMAND: delvewheel repair -w {dest_dir} {wheel}
-          CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: pytest --pyargs prophet
-
-      - name: "Upload wheel as artifact"
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.os }}-wheel
-          path: "./**/*.whl"
-
-  make-wheels-macos-linux:
-    name: ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: ["macos-latest", "ubuntu-latest"]
-      fail-fast: false
-
-    steps:
-      - name: "Checkout repo"
-        uses: actions/checkout@v3
 
       - name: "Build wheels"
         uses: pypa/cibuildwheel@v2.6.0

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -11,12 +11,11 @@ env:
 
 jobs:
   make-wheel-windows:
-    name: ${{ matrix.python-version }}-${{ matrix.architecture }}-${{ matrix.os }}
+    name: ${{ matrix.architecture }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: ["windows-latest"]
-        python-version: [3.8]
         architecture: ["x64"]
       fail-fast: false
 
@@ -37,7 +36,6 @@ jobs:
       - name: "Set up Python"
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}
 
       - name: "Restore pip cache"
@@ -83,12 +81,11 @@ jobs:
           path: "./**/*.whl"
 
   make-wheels-macos-linux:
-    name: ${{ matrix.python-version }}-${{ matrix.architecture }}-${{ matrix.os }}
+    name: ${{ matrix.architecture }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: ["macos-latest", "ubuntu-latest"]
-        python-version: [3.8]
         architecture: ["x64"]
       fail-fast: false
 
@@ -112,7 +109,6 @@ jobs:
       - name: "Set up Python"
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}
 
       - name: "Restore pip cache"
@@ -126,12 +122,12 @@ jobs:
 
       - name: "Install pip"
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install cibuildwheel build
+          python3 -m pip install --upgrade pip
+          python3 -m pip install cibuildwheel build
 
       - name: "Build wheel"
         run: |
-          cd python && python -m cibuildwheel --output-dir wheelhouse
+          cd python && python3 -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ENVIRONMENT: >
             STAN_BACKEND="${{ env.STAN_BACKEND }}"

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -30,12 +30,7 @@ jobs:
           Echo "DEFAULT_HOME=$HOME" >> $env:GITHUB_ENV
 
       - name: "Checkout repo"
-        uses: actions/checkout@v2
-
-      - name: "Set up Python"
-        uses: actions/setup-python@v2
-        with:
-          architecture: ${{ matrix.architecture }}
+        uses: actions/checkout@v3
 
       - name: "Restore pip cache"
         id: cache-pip
@@ -88,54 +83,15 @@ jobs:
       fail-fast: false
 
     steps:
-      - name: "Get OS version (Linux)"
-        if: startsWith(runner.os, 'Linux')
-        run: |
-          echo "PIP_DEFAULT_CACHE=$HOME/.cache/pip" >> $GITHUB_ENV
-          echo "DEFAULT_HOME=$HOME" >> $GITHUB_ENV
-
-      - name: "Get OS version (macOS)"
-        if: startsWith(runner.os, 'macOS')
-        run: |
-          echo "PIP_DEFAULT_CACHE=$HOME/Library/Caches/pip" >> $GITHUB_ENV
-          echo "DEFAULT_HOME=$HOME" >> $GITHUB_ENV
-
-
       - name: "Checkout repo"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: "Set up Python"
-        uses: actions/setup-python@v2
-        with:
-          architecture: ${{ matrix.architecture }}
-
-      - name: "Restore pip cache"
-        id: cache-pip
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.PIP_DEFAULT_CACHE }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/python/requirements.txt') }}-v1
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: "Install pip"
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install cibuildwheel build
-
-      - name: "Build wheel"
-        run: |
-          cd python && python3 -m cibuildwheel --output-dir wheelhouse
+      - name: "Build wheels"
+        uses: pypa/cibuildwheel@v2.6.0
         env:
           CIBW_ENVIRONMENT: >
             STAN_BACKEND="${{ env.STAN_BACKEND }}"
-          # Linux builds run in a Docker container, need to point the cache to the host machine.
-          CIBW_ENVIRONMENT_LINUX: >
-            STAN_BACKEND="${{ env.STAN_BACKEND }}"
-            HOME="/host/${{ env.DEFAULT_HOME }}"
-            PIP_CACHE_DIR="/host/${{ env.PIP_DEFAULT_CACHE }}"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_BEFORE_ALL_LINUX: chmod -R a+rwx /host/${{ env.PIP_DEFAULT_CACHE }}
           CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS: native

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -88,6 +88,8 @@ jobs:
 
       - name: "Build wheels"
         uses: pypa/cibuildwheel@v2.6.0
+        with:
+          package-dir: python
         env:
           CIBW_ENVIRONMENT: >
             STAN_BACKEND="${{ env.STAN_BACKEND }}"
@@ -95,7 +97,6 @@ jobs:
           CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS: native
-          CIBW_BEFORE_ALL: cd python
           CIBW_BUILD_FRONTEND: build
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest --pyargs prophet


### PR DESCRIPTION
This removes manual `pip caching`, which doesn't seem to speed up builds, because `pip` is not a C++ build system, so it can not trace C++ artifacts. TBH, the best way to benefit from caching is to integrate it into the action.