### PR TITLE
Upload wheels to pypi

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -41,7 +41,7 @@ jobs:
           CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS: native
-          CIBW_BUILD_FRONTEND: build --outdir wheelhouse
+          CIBW_BUILD_FRONTEND: build
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest --pyargs prophet
 
@@ -49,7 +49,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.os }}-wheel
-          path: wheelhouse/*
+          path: "./**/*.whl"
 
   upload_wheels:
     name: Upload wheels to PyPi
@@ -59,21 +59,17 @@ jobs:
     steps:
       - uses: actions/download-artifact@v2
         with:
-          name: wheels
-          path: wheelhouse
+          path: dist
 
       - name: Publish package to test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
-          packages_dir: wheelhouse/
 
       - name: Publish package to official PyPI based on release tag
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
           packages_dir: wheelhouse/

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -1,4 +1,4 @@
-name: "Create Python Wheels"
+name: "Create Python Wheels and publish to PyPI"
 
 on:
   release:
@@ -41,7 +41,7 @@ jobs:
           CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS: native
-          CIBW_BUILD_FRONTEND: build
+          CIBW_BUILD_FRONTEND: build --outdir wheelhouse
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest --pyargs prophet
 
@@ -49,4 +49,22 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.os }}-wheel
-          path: "./**/*.whl"
+          path: wheelhouse/*
+
+  upload_wheels:
+    name: Upload wheels to PyPi
+    runs-on: ubuntu-latest
+    needs: [make-wheels]
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: wheels
+          path: wheelhouse
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: ${{ secrets.PYPI_USERNAME }}
+          password: ${{ secrets.PYPI_PASSWORD }}
+          packages_dir: wheelhouse/

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -62,9 +62,18 @@ jobs:
           name: wheels
           path: wheelhouse
 
-      - name: Publish package to PyPI
+      - name: Publish package to test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: ${{ secrets.PYPI_USERNAME }}
-          password: ${{ secrets.PYPI_PASSWORD }}
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          packages_dir: wheelhouse/
+
+      - name: Publish package to official PyPI based on release tag
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
           packages_dir: wheelhouse/


### PR DESCRIPTION
This PR addreses https://github.com/facebook/prophet/pull/2202 and https://github.com/facebook/prophet/issues/664

Based on sktime's publishing script

https://github.com/alan-turing-institute/sktime/blob/main/.github/workflows/wheels.yml

@tcuongd , an initial draft of the Github workflow uploading to PyPI. Can you enable the workflow runs?

@winedarksea, can you please reach out to @bletham to get the PYPI_USERNAME and PYPI_PASSWORD?