### PR TITLE
Add source distribution and upload jobs

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -1,8 +1,8 @@
-name: "Create Python Wheels"
+name: "Create Python distributions and upload to PyPI"
 
 on:
   release:
-    types: [ created ]
+    types: [ published ]
   workflow_dispatch: {}
 
 
@@ -11,7 +11,7 @@ env:
 
 jobs:
   make-wheels:
-    name: ${{ matrix.os }}
+    name: Make ${{ matrix.os }} wheels
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -46,7 +46,43 @@ jobs:
           CIBW_TEST_COMMAND: pytest --pyargs prophet
 
       - name: "Upload wheel as artifact"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.os }}-wheel
+          name: artifact-${{ matrix.os }}-wheel
           path: "./**/*.whl"
+
+  make-sdist:
+    name: Make source distribution
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - run: pipx run build --sdist
+      working-directory: python
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: artifact-source-dist
+        path: "./**/dist/*.tar.gz"
+
+  upload:
+    name: Upload to PyPI
+    needs: [make-wheels, make-sdist]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+    - name: Download all artifacts
+      uses: actions/download-artifact@v3
+
+    - name: Copy artifacts to dist/ folder
+      run: |
+        find . -name 'artifact-*' -exec unzip '{}' \;
+        mkdir -p dist/
+        find . -name '*.tar.gz' -exec mv '{}' dist/ \;
+        find . -name '*.whl' -exec mv '{}' dist/ \;
+
+    - name: Upload
+      uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        user: ${{ secrets.PYPI_USERNAME }}
+        password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
Following the guidance provided by cibuildwheel and pypa: 

* https://cibuildwheel.readthedocs.io/en/stable/deliver-to-pypi/#github-actions 
* https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/

The upload part is conditional on a release being published. I've tested the workflow end-to-end on my fork running manually (normally we would do this to produce wheels for testing first): https://github.com/tcuongd/prophet/actions/runs/2557799360 and by publishing a release: https://github.com/tcuongd/prophet/actions/runs/2557851926

It has successfully uploaded to TestPyPI :)