### PR TITLE
Block broken cmdstanpy versions in pyproject.toml

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -2,6 +2,6 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "cmdstanpy>=1.0.1",
+    "cmdstanpy>=1.0.1, !=1.0.2, !=1.0.3",
 ]
 build-backend = "setuptools.build_meta"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,11 +1,11 @@
 Cython>=0.22
-cmdstanpy>=1.0.1
+cmdstanpy>=1.0.1,!=1.0.2,!=1.0.3
 numpy>=1.15.4
 pandas>=1.0.4
 matplotlib>=2.0.0
 LunarCalendar>=0.0.9
 convertdate>=2.1.2
-holidays>=0.13
+holidays>=0.14.2
 setuptools>=42
 setuptools-git>=1.2
 python-dateutil>=2.8.0


### PR DESCRIPTION
This should close #2214 and close #2216

The cmdstanpy issue is https://github.com/stan-dev/cmdstanpy/issues/585. In short, the wrong directory is set by the `install_cmdstan` function in these versions which leads to it raising a ValueError despite exiting normally. This will be fixed in the next version of cmdstanpy