### PR TITLE
Minor typo in Diagnostics section

### DIFF
--- a/docs/_docs/diagnostics.md
+++ b/docs/_docs/diagnostics.md
@@ -17,7 +17,7 @@ subsections:
 
 
 
-Prophet includes functionality for time series cross validation to measure forecast error using historical data. This is done by selecting cutoff points in the history, and for each of them fitting the model using data only up to that cutoff point. We can then compare the forecasted values to the actual values. This figure illustrates a simulated historical forecast on the Peyton Manning dataset, where the model was fit to a initial history of 5 years, and a forecast was made on a one year horizon.
+Prophet includes functionality for time series cross validation to measure forecast error using historical data. This is done by selecting cutoff points in the history, and for each of them fitting the model using data only up to that cutoff point. We can then compare the forecasted values to the actual values. This figure illustrates a simulated historical forecast on the Peyton Manning dataset, where the model was fit to an initial history of 5 years, and a forecast was made on a one year horizon.
 
 
  


### PR DESCRIPTION
Changed "a initial" to "an initial" in the last sentence of the first paragraph from the Diagnostics: Cross Validation section.