### PR TITLE
Setup: Fix issue with Windows toolchain install

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up R
-      uses: r-lib/actions/setup-r@v1
+      uses: r-lib/actions/setup-r@v2
       with:
         r-version: ${{ matrix.config.r }}
     - name: Install remotes

--- a/python/setup.py
+++ b/python/setup.py
@@ -59,12 +59,16 @@ def repackage_cmdstan():
 def maybe_install_cmdstan_toolchain():
     """Install C++ compilers required to build stan models on Windows machines."""
     import cmdstanpy
-    from cmdstanpy.install_cxx_toolchain import main as _install_cxx_toolchain
-
     try:
         cmdstanpy.utils.cxx_toolchain_path()
     except Exception:
-        _install_cxx_toolchain({"version": None, "dir": None, "verbose": True})
+        try:
+            from cmdstanpy.install_cxx_toolchain import run_rtools_install
+        except ImportError:
+            # older versions
+            from cmdstanpy.install_cxx_toolchain import main as run_rtools_install
+
+        run_rtools_install({"version": None, "dir": None, "verbose": True})
         cmdstanpy.utils.cxx_toolchain_path()
 
 


### PR DESCRIPTION
This supplies two fixes to the setup on windows:

1. Prophet only needs to import the installation utilities for the rtools toolchain if it isn't already installed
2. Fixes the import to use the newer name of the function, rather than the `main` used before. This is still not technically a stable name, but I don't forsee it changing in the future. See: https://github.com/stan-dev/cmdstanpy/issues/588