### PR TITLE
Enable qemu emulation and aarch64 build for prophet

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -94,8 +94,8 @@ jobs:
         find . -name '*.tar.gz' -exec mv '{}' dist/ \;
         find . -name '*.whl' -exec mv '{}' dist/ \;
 
-    # - name: Upload
-    #   uses: pypa/gh-action-pypi-publish@v1.4.2
-    #   with:
-    #     user: ${{ secrets.PYPI_USERNAME }}
-    #     password: ${{ secrets.PYPI_PASSWORD }}
+    - name: Upload
+      uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        user: ${{ secrets.PYPI_USERNAME }}
+        password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -11,15 +11,18 @@ env:
 
 jobs:
   make-wheels:
-    name: Make ${{ matrix.os }} ${{ matrix.cibw_archs }} wheels
+    name: Make ${{ matrix.os }} ${{ matrix.cibw_arch }} ${{ matrix.py_version }} wheels
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: ["macos-latest", "ubuntu-latest", "windows-latest"]
-        cibw_archs: ["native"]
-        include:
-          - os: ubuntu-latest
-            cibw_archs: "aarch64"
+        cibw_arch: ["native", "aarch64"]
+        py_version: ["cp37-*", "cp38-*", "cp39-*", "cp310-*"]
+        exclude:
+          - os: macos-latest
+            cibw_arch: "aarch64"
+          - os: windows-latest
+            cibw_arch: "aarch64"
       fail-fast: false
 
     steps:
@@ -35,7 +38,7 @@ jobs:
           key: ${{ runner.os }}-${{ env.OS_VERSION }}-rtools-v1
 
       - name: Set up QEMU
-        if: matrix.cibw_archs == 'aarch64'
+        if: matrix.cibw_arch == 'aarch64'
         uses: docker/setup-qemu-action@v2
         with:
           platforms: arm64
@@ -48,9 +51,9 @@ jobs:
           CIBW_ENVIRONMENT: >
             STAN_BACKEND="${{ env.STAN_BACKEND }}"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
+          CIBW_BUILD: ${{ matrix.py_version }}
           CIBW_SKIP: "*musllinux*"
-          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+          CIBW_ARCHS: ${{ matrix.cibw_arch }}
           CIBW_BUILD_FRONTEND: build
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest --pyargs prophet
@@ -58,7 +61,7 @@ jobs:
       - name: "Upload wheel as artifact"
         uses: actions/upload-artifact@v3
         with:
-          name: artifact-${{ matrix.os }}-${{ matrix.cibw_archs }}-wheel
+          name: artifact-${{ matrix.os }}-${{ matrix.cibw_arch }}-wheel
           path: "./**/*.whl"
 
   make-sdist:
@@ -91,8 +94,8 @@ jobs:
         find . -name '*.tar.gz' -exec mv '{}' dist/ \;
         find . -name '*.whl' -exec mv '{}' dist/ \;
 
-    - name: Upload
-      uses: pypa/gh-action-pypi-publish@v1.4.2
-      with:
-        user: ${{ secrets.PYPI_USERNAME }}
-        password: ${{ secrets.PYPI_PASSWORD }}
+    # - name: Upload
+    #   uses: pypa/gh-action-pypi-publish@v1.4.2
+    #   with:
+    #     user: ${{ secrets.PYPI_USERNAME }}
+    #     password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -16,6 +16,10 @@ jobs:
     strategy:
       matrix:
         os: ["macos-latest", "ubuntu-latest", "windows-latest"]
+        cibw_archs: ["native"]
+        include:
+          - os: ubuntu-latest
+            cibw_archs: "aarch64"
       fail-fast: false
 
     steps:
@@ -31,10 +35,10 @@ jobs:
           key: ${{ runner.os }}-${{ env.OS_VERSION }}-rtools-v1
 
       - name: Set up QEMU
-        if: runner.os == 'Linux'
+        if: matrix.cibw_archs == 'aarch64'
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: all
+          platforms: arm64
 
       - name: "Build wheels"
         uses: pypa/cibuildwheel@v2.6.0
@@ -46,8 +50,7 @@ jobs:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
           CIBW_SKIP: "*musllinux*"
-          CIBW_ARCHS: native
-          CIBW_ARCHS_LINUX: auto aarch64
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_BUILD_FRONTEND: build
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest --pyargs prophet
@@ -55,7 +58,7 @@ jobs:
       - name: "Upload wheel as artifact"
         uses: actions/upload-artifact@v3
         with:
-          name: artifact-${{ matrix.os }}-wheel
+          name: artifact-${{ matrix.os }}-${{ matric.cibw_archs }}-wheel
           path: "./**/*.whl"
 
   make-sdist:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   make-wheels:
-    name: Make ${{ matrix.os }} wheels
+    name: Make ${{ matrix.os }} ${{ matrix.cibw_archs }} wheels
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -58,7 +58,7 @@ jobs:
       - name: "Upload wheel as artifact"
         uses: actions/upload-artifact@v3
         with:
-          name: artifact-${{ matrix.os }}-${{ matric.cibw_archs }}-wheel
+          name: artifact-${{ matrix.os }}-${{ matrix.cibw_archs }}-wheel
           path: "./**/*.whl"
 
   make-sdist:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -30,6 +30,12 @@ jobs:
           path: C:/rtools40
           key: ${{ runner.os }}-${{ env.OS_VERSION }}-rtools-v1
 
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
+
       - name: "Build wheels"
         uses: pypa/cibuildwheel@v2.6.0
         with:
@@ -41,6 +47,7 @@ jobs:
           CIBW_BUILD: cp37-* cp38-* cp39-* cp310-*
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS: native
+          CIBW_ARCHS_LINUX: auto aarch64
           CIBW_BUILD_FRONTEND: build
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest --pyargs prophet


### PR DESCRIPTION
Prophet==1.1 does not generate an aarch64 wheel. This adds QEMU emulation for linux builds and adds the additional aarch64 platform for linux. 

Note: This follows the pattern set by [matlplotlib](https://github.com/matplotlib/matplotlib/blob/main/.github/workflows/cibuildwheel.yml#L37-L42) using the [CIBW_ARCHS](https://cibuildwheel.readthedocs.io/en/stable/options/#archs) option.