### PR TITLE
Have a single source for __version__

### DIFF
--- a/notebooks/diagnostics.ipynb
+++ b/notebooks/diagnostics.ipynb
@@ -104,7 +104,7 @@
    "source": [
     "### Cross validation\n",
     "\n",
-    "Prophet includes functionality for time series cross validation to measure forecast error using historical data. This is done by selecting cutoff points in the history, and for each of them fitting the model using data only up to that cutoff point. We can then compare the forecasted values to the actual values. This figure illustrates a simulated historical forecast on the Peyton Manning dataset, where the model was fit to a initial history of 5 years, and a forecast was made on a one year horizon."
+    "Prophet includes functionality for time series cross validation to measure forecast error using historical data. This is done by selecting cutoff points in the history, and for each of them fitting the model using data only up to that cutoff point. We can then compare the forecasted values to the actual values. This figure illustrates a simulated historical forecast on the Peyton Manning dataset, where the model was fit to an initial history of 5 years, and a forecast was made on a one year horizon."
    ]
   },
   {

--- a/python/prophet/__init__.py
+++ b/python/prophet/__init__.py
@@ -9,6 +9,6 @@ from prophet.forecaster import Prophet
 from pathlib import Path
 about = {}
 here = Path(__file__).resolve()
-with open(here / "__version__.py", "r", "utf-8") as f:
+with open(here / "__version__.py", "r") as f:
     exec(f.read(), about)
 __version__ = about["__version__"]

--- a/python/prophet/__init__.py
+++ b/python/prophet/__init__.py
@@ -2,9 +2,13 @@
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree. An additional grant 
+# LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
-
 from prophet.forecaster import Prophet
 
-__version__ = '1.1'
+from pathlib import Path
+about = {}
+here = Path(__file__).resolve()
+with open(here / "__version__.py", "r", "utf-8") as f:
+    exec(f.read(), about)
+__version__ = about["__version__"]

--- a/python/prophet/__init__.py
+++ b/python/prophet/__init__.py
@@ -8,7 +8,7 @@ from prophet.forecaster import Prophet
 
 from pathlib import Path
 about = {}
-here = Path(__file__).resolve()
+here = Path(__file__).parent.resolve()
 with open(here / "__version__.py", "r") as f:
     exec(f.read(), about)
 __version__ = about["__version__"]

--- a/python/prophet/__version__.py
+++ b/python/prophet/__version__.py
@@ -1,0 +1,7 @@
+__title__ = "prophet"
+__description__ = "Automatic Forecasting Procedure"
+__url__ = "https://facebook.github.io/prophet/"
+__version__ = "1.1.1"
+__author__ = "Sean J. Taylor <sjtz@pm.me>, Ben Letham <bletham@fb.com>"
+__author_email__ = "sjtz@pm.me"
+__license__ = "MIT"

--- a/python/prophet/models.py
+++ b/python/prophet/models.py
@@ -11,8 +11,6 @@ from typing import Tuple
 from collections import OrderedDict
 from enum import Enum
 from pathlib import Path
-import os
-import pickle
 import pkg_resources
 import platform
 

--- a/python/prophet/serialize.py
+++ b/python/prophet/serialize.py
@@ -10,13 +10,17 @@ from collections import OrderedDict
 from copy import deepcopy
 from io import StringIO
 import json
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
 
 from prophet.forecaster import Prophet
-from prophet import __version__
 
+about = {}
+here = Path(__file__).resolve()
+with open(here / "__version__.py", "r", "utf-8") as f:
+    exec(f.read(), about)
 
 SIMPLE_ATTRIBUTES = [
     'growth', 'n_changepoints', 'specified_changepoints', 'changepoint_range',
@@ -102,7 +106,7 @@ def model_to_dict(model):
     # Params (Dict[str, np.ndarray])
     model_dict['params'] = {k: v.tolist() for k, v in model.params.items()}
     # Attributes that are skipped: stan_fit, stan_backend
-    model_dict['__prophet_version'] = __version__
+    model_dict['__prophet_version'] = about["__version__"]
     return model_dict
 
 

--- a/python/prophet/serialize.py
+++ b/python/prophet/serialize.py
@@ -19,7 +19,7 @@ from prophet.forecaster import Prophet
 
 about = {}
 here = Path(__file__).resolve()
-with open(here / "__version__.py", "r", "utf-8") as f:
+with open(here / "__version__.py", "r") as f:
     exec(f.read(), about)
 
 SIMPLE_ATTRIBUTES = [

--- a/python/prophet/serialize.py
+++ b/python/prophet/serialize.py
@@ -18,7 +18,7 @@ import pandas as pd
 from prophet.forecaster import Prophet
 
 about = {}
-here = Path(__file__).resolve()
+here = Path(__file__).parent.resolve()
 with open(here / "__version__.py", "r") as f:
     exec(f.read(), about)
 

--- a/python/prophet/tests/test_serialize.py
+++ b/python/prophet/tests/test_serialize.py
@@ -40,9 +40,6 @@ class TestSerialize(TestCase):
         model_str = model_to_json(m)
         # Make sure json doesn't get too large in the future
         self.assertTrue(len(model_str) < 200000)
-        z = json.loads(model_str)
-        self.assertEqual(z['__prophet_version'], '1.1')
-
         m2 = model_from_json(model_str)
 
         # Check that m and m2 are equal

--- a/python/setup.py
+++ b/python/setup.py
@@ -228,7 +228,7 @@ with open("requirements.txt", "r") as f:
     install_requires = f.read().splitlines()
 
 about = {}
-here = Path(__file__).resolve()
+here = Path(__file__).parent.resolve()
 with open(here / "prophet" /  "__version__.py", "r") as f:
     exec(f.read(), about)
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -227,17 +227,22 @@ with open("README.md", "r", encoding="utf-8") as f:
 with open("requirements.txt", "r") as f:
     install_requires = f.read().splitlines()
 
+about = {}
+here = Path(__file__).resolve()
+with open(here / "prophet" /  "__version__.py", "r", "utf-8") as f:
+    exec(f.read(), about)
+
 setup(
-    name="prophet",
-    version="1.1",
-    description="Automatic Forecasting Procedure",
-    url="https://facebook.github.io/prophet/",
+    name=about["__title__"],
+    version=about["__version__"],
+    description=about["__description__"],
+    url=about["__url__"],
     project_urls={
         "Source": "https://github.com/facebook/prophet",
     },
-    author="Sean J. Taylor <sjtz@pm.me>, Ben Letham <bletham@fb.com>",
-    author_email="sjtz@pm.me",
-    license="MIT",
+    author=about["__author__"],
+    author_email=about["__author_email__"],
+    license=about["__license__"],
     packages=find_packages(),
     install_requires=install_requires,
     python_requires=">=3.7",

--- a/python/setup.py
+++ b/python/setup.py
@@ -229,7 +229,7 @@ with open("requirements.txt", "r") as f:
 
 about = {}
 here = Path(__file__).resolve()
-with open(here / "prophet" /  "__version__.py", "r", "utf-8") as f:
+with open(here / "prophet" /  "__version__.py", "r") as f:
     exec(f.read(), about)
 
 setup(


### PR DESCRIPTION
* Prevents the need to bump version numbers in multiple places. We choose option 3 here: https://packaging.python.org/en/latest/guides/single-sourcing-package-version/ modelling off the requests packagee: https://github.com/psf/requests
* Should also prevent the circular reference that was causing import issues for the `model_to_dict()` function.