### PR TITLE
Incorporate cmdstanpy v1.0.4 updates

### DIFF
--- a/python/prophet/models.py
+++ b/python/prophet/models.py
@@ -6,7 +6,6 @@
 
 from __future__ import absolute_import, division, print_function
 from abc import abstractmethod, ABC
-from tempfile import mkdtemp
 from typing import Tuple
 from collections import OrderedDict
 from enum import Enum
@@ -92,7 +91,6 @@ class CmdStanPyBackend(IStanBackend):
             inits=stan_init,
             algorithm='Newton' if stan_data['T'] < 100 else 'LBFGS',
             iter=int(1e4),
-            output_dir = mkdtemp(),
         )
         args.update(kwargs)
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -2,6 +2,6 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "cmdstanpy>=1.0.1, !=1.0.2, !=1.0.3",
+    "cmdstanpy>=1.0.4",
 ]
 build-backend = "setuptools.build_meta"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 Cython>=0.22
-cmdstanpy>=1.0.1,!=1.0.2,!=1.0.3
+cmdstanpy>=1.0.4
 numpy>=1.15.4
 pandas>=1.0.4
 matplotlib>=2.0.0


### PR DESCRIPTION
* cmdstanpy now creates a new temporary directory for each model run by default, removing the issue with collisions during cross validation.
* cmdstanpy also cleans up the temp files with atexit, whereas our current solution with mkdtemp() did not.
* Bumped cmdstanpy to v1.0.4 to incorporate these changes (1.0.2, 1.0.3 are not compatible with prophet).
* Local testing ran fine for normal fitting and cross-validation via processes and threads. Will merge if CI passes

Closes:
* https://github.com/facebook/prophet/issues/2253
* https://github.com/facebook/prophet/pull/2160