### PR TITLE
Speed up `fourier_series`

### DIFF
--- a/python/prophet/forecaster.py
+++ b/python/prophet/forecaster.py
@@ -435,6 +435,9 @@ class Prophet(object):
         -------
         Matrix with seasonality features.
         """
+        if not (series_order >= 1):
+            raise ValueError("series_order must be >= 1")
+
         # convert to days since epoch
         t = dates.to_numpy(dtype=int) // NANOSECONDS_TO_SECONDS / (3600 * 24.)
 

--- a/python/prophet/forecaster.py
+++ b/python/prophet/forecaster.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function
 import logging
 from collections import OrderedDict, defaultdict
 from copy import deepcopy
-from datetime import timedelta, datetime
+from datetime import timedelta
 from typing import Dict, List
 
 import numpy as np
@@ -21,7 +21,7 @@ from prophet.plot import (plot, plot_components)
 
 logger = logging.getLogger('prophet')
 logger.setLevel(logging.INFO)
-
+NANOSECONDS_TO_SECONDS = 1000 * 1000 * 1000
 
 class Prophet(object):
     """Prophet forecaster.
@@ -436,11 +436,8 @@ class Prophet(object):
         Matrix with seasonality features.
         """
         # convert to days since epoch
-        t = np.array(
-            (dates - datetime(1970, 1, 1))
-                .dt.total_seconds()
-                .astype(float)
-        ) / (3600 * 24.)
+        t = dates.to_numpy(dtype=int) // NANOSECONDS_TO_SECONDS / (3600 * 24.)
+
         return np.column_stack([
             fun((2.0 * (i + 1) * np.pi * t / period))
             for i in range(series_order)

--- a/python/prophet/forecaster.py
+++ b/python/prophet/forecaster.py
@@ -10,10 +10,11 @@ import logging
 from collections import OrderedDict, defaultdict
 from copy import deepcopy
 from datetime import timedelta
-from typing import Dict, List
+from typing import Dict, List, Union
 
 import numpy as np
 import pandas as pd
+from numpy.typing import NDArray
 
 from prophet.make_holidays import get_holiday_names, make_holidays_df
 from prophet.models import StanBackendEnum
@@ -421,7 +422,11 @@ class Prophet(object):
             self.changepoints_t = np.array([0])  # dummy changepoint
 
     @staticmethod
-    def fourier_series(dates, period, series_order):
+    def fourier_series(
+        dates: pd.Series,
+        period: Union[int, float],
+        series_order: int,
+    ) -> NDArray[np.float_]:
         """Provides Fourier series components with the specified frequency
         and order.
 

--- a/python/prophet/forecaster.py
+++ b/python/prophet/forecaster.py
@@ -447,12 +447,12 @@ class Prophet(object):
         t = dates.to_numpy(dtype=int) // NANOSECONDS_TO_SECONDS / (3600 * 24.)
 
         x_T = t * np.pi * 2
-        O = np.empty((dates.shape[0], 2 * series_order))
+        fourier_components = np.empty((dates.shape[0], 2 * series_order))
         for i in range(series_order):
-            cycle = x_T * (i + 1) / period
-            O[:, 2 * i] = np.sin(cycle)
-            O[:, (2 * i) + 1] = np.cos(cycle)
-        return O
+            c = x_T * (i + 1) / period
+            fourier_components[:, 2 * i] = np.sin(c)
+            fourier_components[:, (2 * i) + 1] = np.cos(c)
+        return fourier_components
 
     @classmethod
     def make_seasonality_features(cls, dates, period, series_order, prefix):

--- a/python/prophet/forecaster.py
+++ b/python/prophet/forecaster.py
@@ -438,11 +438,13 @@ class Prophet(object):
         # convert to days since epoch
         t = dates.to_numpy(dtype=int) // NANOSECONDS_TO_SECONDS / (3600 * 24.)
 
-        return np.column_stack([
-            fun((2.0 * (i + 1) * np.pi * t / period))
-            for i in range(series_order)
-            for fun in (np.sin, np.cos)
-        ])
+        x_T = t * np.pi * 2
+        O = np.empty((dates.shape[0], 2 * series_order))
+        for i in range(series_order):
+            cycle = x_T * (i + 1) / period
+            O[:, 2 * i] = np.sin(cycle)
+            O[:, (2 * i) + 1] = np.cos(cycle)
+        return O
 
     @classmethod
     def make_seasonality_features(cls, dates, period, series_order, prefix):


### PR DESCRIPTION
This PR speeds up the fourier series computation by:
- speeding up the conversion to days since epoch
- pre-allocating the numpy array and optimizing the for loop

```py
%timeit Prophet.fourier_series(DATA["ds"], 7, 3)
```
`main`
169 µs ± 1.38 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

This PR
30.9 µs ± 699 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

Also added in this PR:
- raise error if `series_order` is < 1
- added typing to the method