### PR TITLE
fourier_series: fix Windows `int` -> `np.int64` dtype

### DIFF
--- a/python/prophet/forecaster.py
+++ b/python/prophet/forecaster.py
@@ -444,7 +444,7 @@ class Prophet(object):
             raise ValueError("series_order must be >= 1")
 
         # convert to days since epoch
-        t = dates.to_numpy(dtype=int) // NANOSECONDS_TO_SECONDS / (3600 * 24.)
+        t = dates.to_numpy(dtype=np.int64) // NANOSECONDS_TO_SECONDS / (3600 * 24.)
 
         x_T = t * np.pi * 2
         fourier_components = np.empty((dates.shape[0], 2 * series_order))


### PR DESCRIPTION
Default numpy dtype on Windows is int32, use explicit np.int64 dtype to fix conversion (see https://stackoverflow.com/questions/36278590/numpy-array-dtype-is-coming-as-int32-by-default-in-a-windows-10-64-bit-machine)

re https://github.com/facebook/prophet/pull/2336#issuecomment-1379701487

On Windows 11 x64
`main`
```
In  [1]: dates.to_numpy(int).dtype
Out [1]: dtype('int32')
```

This PR
```
In  [1]: dates.to_numpy(np.int64).dtype
Out [1]: dtype('int64')
```