### PR TITLE
Sanitize warm start parameters

### DIFF
--- a/docs/_docs/additional_topics.md
+++ b/docs/_docs/additional_topics.md
@@ -82,11 +82,12 @@ A common setting for forecasting is fitting models that need to be updated as ad
 
 ```python
 # Python
-def get_stan_init(m):
-    """Retrieve parameters from a trained model.
-
-    Retrieve parameters from a trained model in the format
-    used to initialize a new Stan model.
+def warm_start_params(m):
+    """
+    Retrieve parameters from a trained model in the format used to initialize a new Stan model.
+    Note that the new Stan model must have these same settings:
+        n_changepoints, seasonality features, mcmc sampling
+    for the retrieved parameters to be valid for the new model.
 
     Parameters
     ----------
@@ -115,7 +116,7 @@ m1 = Prophet().fit(df1) # A model fit to all data except the last day
 
 
 %timeit m2 = Prophet().fit(df)  # Adding the last day, fitting from scratch
-%timeit m2 = Prophet().fit(df, init=get_stan_init(m1))  # Adding the last day, warm-starting from m1
+%timeit m2 = Prophet().fit(df, init=warm_start_params(m1))  # Adding the last day, warm-starting from m1
 ```
     1.33 s ± 55.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
     185 ms ± 4.46 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

--- a/notebooks/additional_topics.ipynb
+++ b/notebooks/additional_topics.ipynb
@@ -216,11 +216,12 @@
     }
    ],
    "source": [
-    "def get_stan_init(m):\n",
-    "    \"\"\"Retrieve parameters from a trained model.\n",
-    "\n",
-    "    Retrieve parameters from a trained model in the format\n",
-    "    used to initialize a new Stan model.\n",
+    "def warm_start_params(m):\n",
+    "    \"\"\"\n",
+    "    Retrieve parameters from a trained model in the format used to initialize a new Stan model.\n",
+    "    Note that the new Stan model must have these same settings:\n",
+    "        n_changepoints, seasonality features, mcmc sampling\n",
+    "    for the retrieved parameters to be valid for the new model.\n",
     "\n",
     "    Parameters\n",
     "    ----------\n",
@@ -249,7 +250,7 @@
     "\n",
     "\n",
     "%timeit m2 = Prophet().fit(df)  # Adding the last day, fitting from scratch\n",
-    "%timeit m2 = Prophet().fit(df, init=get_stan_init(m1))  # Adding the last day, warm-starting from m1"
+    "%timeit m2 = Prophet().fit(df, init=warm_start_params(m1))  # Adding the last day, warm-starting from m1"
    ]
   },
   {
@@ -275,7 +276,7 @@
  "metadata": {
   "celltoolbar": "Edit Metadata",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -289,7 +290,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.10 (default, Mar 25 2022, 22:18:25) \n[Clang 12.0.5 (clang-1205.0.22.11)]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "9f764ff66e3236555d51a00749f5293db82082e341e153963b8b2deea93b52fc"
+   }
   }
  },
  "nbformat": 4,

--- a/python/prophet/utilities.py
+++ b/python/prophet/utilities.py
@@ -75,3 +75,31 @@ def regressor_coefficients(m):
         coefs.append(record)
 
     return pd.DataFrame(coefs)
+
+def warm_start_params(m):
+    """
+    Retrieve parameters from a trained model in the format used to initialize a new Stan model.
+    Note that the new Stan model must have these same settings:
+        n_changepoints, seasonality features, mcmc sampling
+    for the retrieved parameters to be valid for the new model.
+
+    Parameters
+    ----------
+    m: A trained model of the Prophet class.
+
+    Returns
+    -------
+    A Dictionary containing retrieved parameters of m.
+    """
+    res = {}
+    for pname in ['k', 'm', 'sigma_obs']:
+        if m.mcmc_samples == 0:
+            res[pname] = m.params[pname][0][0]
+        else:
+            res[pname] = np.mean(m.params[pname])
+    for pname in ['delta', 'beta']:
+        if m.mcmc_samples == 0:
+            res[pname] = m.params[pname][0]
+        else:
+            res[pname] = np.mean(m.params[pname], axis=0)
+    return res


### PR DESCRIPTION
This is a follow-up to https://github.com/facebook/prophet/pull/2335 which tested fine on Ubuntu and Windows but failed on macOS (see https://github.com/facebook/prophet/pull/2336#issuecomment-1379701487). It turns out that `beta` (i.e. seasonal features + extra regressors) had a different length in each of the initial and new models. Ubuntu and Windows dealt with it (I'm not sure exactly how) but macOS did not. Technically though, we shouldn't be using warm start values from models with different-shaped `delta` (number of changepoints) or `beta`, since the warm values are unlikely to line up with what needs to be fitted in the new model.

The solution proposed here is to sanitize the custom inits: if they don't match the type and shape of the default, we revert to the default. I've done this by adding a new method in `CmdStanPyBackend` and refactoring the fit and sampling methods a little.

I've also added the `warm_start_params` function to the utilities module, to save end users having to copy-paste code from the documentation.

Successful local testing on macOS:

```
python-F3JeUycv ❯ python -m pytest python/prophet/tests/test_prophet.py::TestProphet -k "warm"
======================================================== test session starts ========================================================
platform darwin -- Python 3.8.10, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/cuong/projects/prophet/python
plugins: anyio-3.6.1
collected 40 items / 38 deselected / 2 selected

python/prophet/tests/test_prophet.py ..                                                                                       [100%]

================================================= 2 passed, 38 deselected in 11.11s =================================================
```