### PR TITLE
setuptools is not only a dev dependency

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "holidays>=0.14.2",
   "python-dateutil>=2.8.0",
   "tqdm>=4.36.1",
+  "setuptools>=64",
 ]
 authors = [
   {name = "Sean J. Taylor", email = "sjtz@pm.me"},
@@ -43,7 +44,6 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
-  "setuptools>=64",
   "wheel",
   "pytest",
   "jupyterlab",


### PR DESCRIPTION
pyproject.toml declares that setuptools is a dev only dependency, but in fact it is needed unconditionally - per this import: https://github.com/facebook/prophet/blob/0bf05baf3c4ace5e02e18a432ec6c2d734a97034/python/prophet/models.py#L13.