### PR TITLE
Migrate pkg_resources to importlib_resources

### DIFF
--- a/python/prophet/models.py
+++ b/python/prophet/models.py
@@ -9,8 +9,7 @@ from abc import abstractmethod, ABC
 from typing import Tuple
 from collections import OrderedDict
 from enum import Enum
-from pathlib import Path
-import pkg_resources
+import importlib_resources
 import platform
 
 import logging
@@ -59,11 +58,9 @@ class CmdStanPyBackend(IStanBackend):
     def __init__(self):
         import cmdstanpy
         # this must be set before super.__init__() for load_model to work on Windows
-        local_cmdstan = pkg_resources.resource_filename(
-            "prophet", f"stan_model/cmdstan-{self.CMDSTAN_VERSION}"
-        )
-        if Path(local_cmdstan).exists():
-            cmdstanpy.set_cmdstan_path(local_cmdstan)
+        local_cmdstan = importlib_resources.files("prophet").joinpath(f"stan_model/cmdstan-{self.CMDSTAN_VERSION}")
+        if local_cmdstan.exists():
+            cmdstanpy.set_cmdstan_path(str(local_cmdstan))
         super().__init__()
 
     @staticmethod
@@ -72,11 +69,8 @@ class CmdStanPyBackend(IStanBackend):
 
     def load_model(self):
         import cmdstanpy
-        model_file = pkg_resources.resource_filename(
-            'prophet',
-            'stan_model/prophet_model.bin',
-        )
-        return cmdstanpy.CmdStanModel(exe_file=model_file)
+        model_file = importlib_resources.files("prophet").joinpath("stan_model/prophet_model.bin")
+        return cmdstanpy.CmdStanModel(exe_file=str(model_file))
 
     def fit(self, stan_init, stan_data, **kwargs):
         if 'inits' not in kwargs and 'init' in kwargs:

--- a/python/prophet/models.py
+++ b/python/prophet/models.py
@@ -58,7 +58,7 @@ class CmdStanPyBackend(IStanBackend):
     def __init__(self):
         import cmdstanpy
         # this must be set before super.__init__() for load_model to work on Windows
-        local_cmdstan = importlib_resources.files("prophet").joinpath(f"stan_model/cmdstan-{self.CMDSTAN_VERSION}")
+        local_cmdstan = importlib_resources.files("prophet") / "stan_model" / f"cmdstan-{self.CMDSTAN_VERSION}"
         if local_cmdstan.exists():
             cmdstanpy.set_cmdstan_path(str(local_cmdstan))
         super().__init__()
@@ -69,7 +69,7 @@ class CmdStanPyBackend(IStanBackend):
 
     def load_model(self):
         import cmdstanpy
-        model_file = importlib_resources.files("prophet").joinpath("stan_model/prophet_model.bin")
+        model_file = importlib_resources.files("prophet") / "stan_model" / "prophet_model.bin"
         return cmdstanpy.CmdStanModel(exe_file=str(model_file))
 
     def fit(self, stan_init, stan_data, **kwargs):

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "holidays>=0.14.2",
   "python-dateutil>=2.8.0",
   "tqdm>=4.36.1",
+  "importlib_resources",
 ]
 authors = [
   {name = "Sean J. Taylor", email = "sjtz@pm.me"},
@@ -56,6 +57,6 @@ parallel = [
 ]
 
 [project.urls]
-homepage = "https://facebook.github.io/prophet/"
-documentation = "https://facebook.github.io/prophet/"
-repository = "https://github.com/facebook/prophet"
+Homepage = "https://facebook.github.io/prophet/"
+Documentation = "https://facebook.github.io/prophet/"
+Repository = "https://github.com/facebook/prophet"


### PR DESCRIPTION
So we don't need to have `setuptools` in the dependencies list, reported here: https://github.com/facebook/prophet/pull/2351

`pkg_resources` is deprecated in favour of `importlib_resources` anyways: https://importlib-resources.readthedocs.io/en/latest/migration.html

### Local testing (macOS)

```
python-F3JeUycv ❯ python -m pytest prophet/tests/
===================================================== test session starts =====================================================
platform darwin -- Python 3.8.10, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/cuong/projects/prophet/python
plugins: anyio-3.6.1
collected 55 items

prophet/tests/test_diagnostics.py ...........                                                                           [ 20%]
prophet/tests/test_prophet.py ............s...s.......................                                                  [ 92%]
prophet/tests/test_serialize.py ...                                                                                     [ 98%]
prophet/tests/test_utilities.py .                                                                                       [100%]
```