### PR TITLE
Make sure 'mu' and 'std' are not numpy floats

### DIFF
--- a/python/prophet/forecaster.py
+++ b/python/prophet/forecaster.py
@@ -367,8 +367,8 @@ class Prophet(object):
                 else:
                     standardize = True
             if standardize:
-                mu = df[name].mean()
-                std = df[name].std()
+                mu = float(df[name].mean())
+                std = float(df[name].std())
                 self.extra_regressors[name]['mu'] = mu
                 self.extra_regressors[name]['std'] = std
 


### PR DESCRIPTION
Hi,
I encountered a similar issue like https://github.com/facebook/prophet/issues/1824, where the target value (i.e. `y`) was np.float32, then the computed `y_scale` was np.float32 as well, which caused json serialization to fail.

In my scenario, the extra regressors were np.float32, so `mu` and `std` are also np.float32 and I'm unable to serialize the model (of course after calling `model_to_dict`).

The solution is just to convert it to float, same as in https://github.com/facebook/prophet/commit/9e4e87af9baad421442a62206a6cb705ef4f612f.

Thanks!