### PR TITLE
Refactor tests - use fixtures and parametrization, allow backend argument

### DIFF
--- a/python/prophet/tests/conftest.py
+++ b/python/prophet/tests/conftest.py
@@ -40,5 +40,12 @@ def pytest_collection_modifyitems(config, items):
 
 
 def pytest_generate_tests(metafunc):
+    """
+    For each test, if `backend` is used as a fixture, add a parametrization equal to the value of the
+    --backend option.
+
+    This is used to re-run the test suite for different probabilistic programming language backends
+    (e.g. cmdstanpy, numpyro).
+    """
     if "backend" in metafunc.fixturenames:
         metafunc.parametrize("backend", metafunc.config.getoption("backend"))

--- a/python/prophet/tests/conftest.py
+++ b/python/prophet/tests/conftest.py
@@ -1,4 +1,19 @@
+from pathlib import Path
+
+import pandas as pd
 import pytest
+
+
+@pytest.fixture(scope="package")
+def daily_univariate_ts() -> pd.DataFrame:
+    """Daily univariate time series with 2 years of data"""
+    return pd.read_csv(Path(__file__).parent / "data.csv", parse_dates=["ds"])
+
+
+@pytest.fixture(scope="package")
+def subdaily_univariate_ts() -> pd.DataFrame:
+    """Sub-daily univariate time series"""
+    return pd.read_csv(Path(__file__).parent / "data2.csv", parse_dates=["ds"])
 
 
 def pytest_configure(config):
@@ -7,6 +22,12 @@ def pytest_configure(config):
 
 def pytest_addoption(parser):
     parser.addoption("--test-slow", action="store_true", default=False, help="Run slow tests")
+    parser.addoption(
+        "--backend",
+        nargs="+",
+        default=["CMDSTANPY"],
+        help="Probabilistic Programming Language backend to perform tests with.",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -16,3 +37,8 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "slow" in item.keywords:
             item.add_marker(skip_slow)
+
+
+def pytest_generate_tests(metafunc):
+    if "backend" in metafunc.fixturenames:
+        metafunc.parametrize("backend", metafunc.config.getoption("backend"))

--- a/python/prophet/tests/test_diagnostics.py
+++ b/python/prophet/tests/test_diagnostics.py
@@ -3,27 +3,19 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
+import datetime
 import itertools
-import os
-from unittest import TestCase
-from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
-import datetime
+import pytest
 
-from prophet import Prophet
-from prophet import diagnostics
+from prophet import Prophet, diagnostics
 
-DATA_all = pd.read_csv(
-    os.path.join(os.path.dirname(__file__), 'data.csv'), parse_dates=['ds']
-)
-DATA = DATA_all.head(100)
+
+@pytest.fixture(scope="module")
+def ts_short(daily_univariate_ts):
+    return daily_univariate_ts.head(100)
 
 
 class CustomParallelBackend:
@@ -32,327 +24,338 @@ class CustomParallelBackend:
         return results
 
 
-class TestDiagnostics(TestCase):
+PARALLEL_METHODS = [None, "processes", "threads", CustomParallelBackend()]
+try:
+    from dask.distributed import Client
 
-    def __init__(self, *args, **kwargs):
-        super(TestDiagnostics, self).__init__(*args, **kwargs)
-        # Use first 100 record in data.csv
-        self.__df = DATA
+    client = Client(processes=False)  # noqa
+    PARALLEL_METHODS.append("dask")
+except ImportError:
+    pass
 
-    def test_cross_validation(self):
-        m = Prophet()
-        m.fit(self.__df)
+
+class TestCrossValidation:
+    @pytest.mark.parametrize("parallel_method", PARALLEL_METHODS)
+    def test_cross_validation(self, ts_short, parallel_method, backend):
+        m = Prophet(stan_backend=backend)
+        m.fit(ts_short)
         # Calculate the number of cutoff points(k)
-        horizon = pd.Timedelta('4 days')
-        period = pd.Timedelta('10 days')
-        initial = pd.Timedelta('115 days')
-        methods = [None, 'processes', 'threads', CustomParallelBackend()]
+        horizon = pd.Timedelta("4 days")
+        period = pd.Timedelta("10 days")
+        initial = pd.Timedelta("115 days")
+        df_cv = diagnostics.cross_validation(
+            m, horizon="4 days", period="10 days", initial="115 days", parallel=parallel_method
+        )
+        assert len(np.unique(df_cv["cutoff"])) == 3
+        assert max(df_cv["ds"] - df_cv["cutoff"]) == horizon
+        assert min(df_cv["cutoff"]) >= min(ts_short["ds"]) + initial
+        dc = df_cv["cutoff"].diff()
+        dc = dc[dc > pd.Timedelta(0)].min()
+        assert dc >= period
+        assert (df_cv["cutoff"] < df_cv["ds"]).all()
+        # Each y in df_cv and ts_short with same ds should be equal
+        df_merged = pd.merge(df_cv, ts_short, "left", on="ds")
+        assert np.sum((df_merged["y_x"] - df_merged["y_y"]) ** 2) == pytest.approx(0.0)
+        df_cv = diagnostics.cross_validation(
+            m, horizon="4 days", period="10 days", initial="135 days"
+        )
+        assert len(np.unique(df_cv["cutoff"])) == 1
+        with pytest.raises(ValueError):
+            diagnostics.cross_validation(m, horizon="10 days", period="10 days", initial="140 days")
 
-        try:
-            from dask.distributed import Client
-            client = Client(processes=False)  # noqa
-            methods.append("dask")
-        except ImportError:
-            pass
-
-        for parallel in methods:
-            with self.subTest(i=parallel):
-                df_cv = diagnostics.cross_validation(
-                    m, horizon='4 days', period='10 days', initial='115 days',
-                    parallel=parallel)
-                self.assertEqual(len(np.unique(df_cv['cutoff'])), 3)
-                self.assertEqual(max(df_cv['ds'] - df_cv['cutoff']), horizon)
-                self.assertTrue(min(df_cv['cutoff']) >= min(self.__df['ds']) + initial)
-                dc = df_cv['cutoff'].diff()
-                dc = dc[dc > pd.Timedelta(0)].min()
-                self.assertTrue(dc >= period)
-                self.assertTrue((df_cv['cutoff'] < df_cv['ds']).all())
-                # Each y in df_cv and self.__df with same ds should be equal
-                df_merged = pd.merge(df_cv, self.__df, 'left', on='ds')
-                self.assertAlmostEqual(
-                    np.sum((df_merged['y_x'] - df_merged['y_y']) ** 2), 0.0)
-                df_cv = diagnostics.cross_validation(
-                    m, horizon='4 days', period='10 days', initial='135 days')
-                self.assertEqual(len(np.unique(df_cv['cutoff'])), 1)
-                with self.assertRaises(ValueError):
-                    diagnostics.cross_validation(
-                        m, horizon='10 days', period='10 days', initial='140 days')
-
+    def test_bad_parallel_methods(self, ts_short, backend):
+        m = Prophet(stan_backend=backend)
+        m.fit(ts_short)
         # invalid alias
-        with self.assertRaisesRegex(ValueError, "'parallel' should be one"):
+        with pytest.raises(ValueError, match="'parallel' should be one"):
             diagnostics.cross_validation(m, horizon="4 days", parallel="bad")
-
         # no map method
-        with self.assertRaisesRegex(ValueError, "'parallel' should be one"):
+        with pytest.raises(ValueError, match="'parallel' should be one"):
             diagnostics.cross_validation(m, horizon="4 days", parallel=object())
 
+    def test_check_single_cutoff_forecast_func_calls(self, ts_short, monkeypatch, backend):
+        m = Prophet(stan_backend=backend)
+        m.fit(ts_short)
 
-    def test_check_single_cutoff_forecast_func_calls(self):
-        m = Prophet()
-        m.fit(self.__df)
-        mock_predict = pd.DataFrame({'ds':pd.date_range(start='2012-09-17', periods=3),
-                                     'yhat':np.arange(16, 19),
-                                     'yhat_lower':np.arange(15, 18),
-                                     'yhat_upper': np.arange(17, 20),
-                                      'y': np.arange(16.5, 19.5),
-                                     'cutoff': [datetime.date(2012, 9, 15)]*3})
+        def mock_predict(df, model, cutoff, horizon, predict_columns):
+            nonlocal n_calls
+            n_calls = n_calls + 1
+            return pd.DataFrame(
+                {
+                    "ds": pd.date_range(start="2012-09-17", periods=3),
+                    "yhat": np.arange(16, 19),
+                    "yhat_lower": np.arange(15, 18),
+                    "yhat_upper": np.arange(17, 20),
+                    "y": np.arange(16.5, 19.5),
+                    "cutoff": [datetime.date(2012, 9, 15)] * 3,
+                }
+            )
 
+        monkeypatch.setattr(diagnostics, "single_cutoff_forecast", mock_predict)
         # cross validation  with 3 and 7 forecasts
-        for args, forecasts in ((['4 days', '10 days', '115 days'], 3),
-                            (['4 days', '4 days', '115 days'], 7)):
-            with patch('prophet.diagnostics.single_cutoff_forecast') as mock_func:
-                mock_func.return_value = mock_predict
-                df_cv = diagnostics.cross_validation(m, *args)
-                # check single forecast function called expected number of times
-                self.assertEqual(diagnostics.single_cutoff_forecast.call_count,
-                                 forecasts)
+        for args, forecasts in (
+            (["4 days", "10 days", "115 days"], 3),
+            (["4 days", "4 days", "115 days"], 7),
+        ):
+            n_calls = 0
+            _ = diagnostics.cross_validation(m, *args)
+            # check single forecast function called expected number of times
+            assert n_calls == forecasts
 
-    def test_cross_validation_logistic_or_flat_growth(self):
-        params = (x for x in ['logistic', 'flat'])
-        for growth in params:
-            with self.subTest(i=growth):
-                df = self.__df.copy()
-                if growth == "logistic":
-                    df['cap'] = 40
-                m = Prophet(growth=growth).fit(df)
-                df_cv = diagnostics.cross_validation(
-                    m, horizon='1 days', period='1 days', initial='140 days')
-                self.assertEqual(len(np.unique(df_cv['cutoff'])), 2)
-                self.assertTrue((df_cv['cutoff'] < df_cv['ds']).all())
-                df_merged = pd.merge(df_cv, self.__df, 'left', on='ds')
-                self.assertAlmostEqual(
-                    np.sum((df_merged['y_x'] - df_merged['y_y']) ** 2), 0.0)
+    @pytest.mark.parametrize("growth", ["logistic", "flat"])
+    def test_cross_validation_logistic_or_flat_growth(self, growth, ts_short, backend):
+        df = ts_short.copy()
+        if growth == "logistic":
+            df["cap"] = 40
+        m = Prophet(growth=growth, stan_backend=backend).fit(df)
+        df_cv = diagnostics.cross_validation(
+            m, horizon="1 days", period="1 days", initial="140 days"
+        )
+        assert len(np.unique(df_cv["cutoff"])) == 2
+        assert (df_cv["cutoff"] < df_cv["ds"]).all()
+        df_merged = pd.merge(df_cv, ts_short, "left", on="ds")
+        assert np.sum((df_merged["y_x"] - df_merged["y_y"]) ** 2) == pytest.approx(0.0)
 
-    def test_cross_validation_extra_regressors(self):
-        df = self.__df.copy()
-        df['extra'] = range(df.shape[0])
-        df['is_conditional_week'] = np.arange(df.shape[0]) // 7 % 2
-        m = Prophet()
-        m.add_seasonality(name='monthly', period=30.5, fourier_order=5)
-        m.add_seasonality(name='conditional_weekly', period=7, fourier_order=3,
-                          prior_scale=2., condition_name='is_conditional_week')
-        m.add_regressor('extra')
+    def test_cross_validation_extra_regressors(self, ts_short, backend):
+        df = ts_short.copy()
+        df["extra"] = range(df.shape[0])
+        df["is_conditional_week"] = np.arange(df.shape[0]) // 7 % 2
+        m = Prophet(stan_backend=backend)
+        m.add_seasonality(name="monthly", period=30.5, fourier_order=5)
+        m.add_seasonality(
+            name="conditional_weekly",
+            period=7,
+            fourier_order=3,
+            prior_scale=2.0,
+            condition_name="is_conditional_week",
+        )
+        m.add_regressor("extra")
         m.fit(df)
         df_cv = diagnostics.cross_validation(
-            m, horizon='4 days', period='4 days', initial='135 days')
-        self.assertEqual(len(np.unique(df_cv['cutoff'])), 2)
-        period = pd.Timedelta('4 days')
-        dc = df_cv['cutoff'].diff()
+            m, horizon="4 days", period="4 days", initial="135 days"
+        )
+        assert len(np.unique(df_cv["cutoff"])) == 2
+        period = pd.Timedelta("4 days")
+        dc = df_cv["cutoff"].diff()
         dc = dc[dc > pd.Timedelta(0)].min()
-        self.assertTrue(dc >= period)
-        self.assertTrue((df_cv['cutoff'] < df_cv['ds']).all())
-        df_merged = pd.merge(df_cv, self.__df, 'left', on='ds')
-        self.assertAlmostEqual(
-            np.sum((df_merged['y_x'] - df_merged['y_y']) ** 2), 0.0)
+        assert dc >= period
+        assert (df_cv["cutoff"] < df_cv["ds"]).all()
+        df_merged = pd.merge(df_cv, ts_short, "left", on="ds")
+        assert np.sum((df_merged["y_x"] - df_merged["y_y"]) ** 2) == pytest.approx(0.0)
 
-    def test_cross_validation_default_value_check(self):
-        m = Prophet()
-        m.fit(self.__df)
+    def test_cross_validation_default_value_check(self, ts_short, backend):
+        m = Prophet(stan_backend=backend)
+        m.fit(ts_short)
         # Default value of initial should be equal to 3 * horizon
-        df_cv1 = diagnostics.cross_validation(
-            m, horizon='32 days', period='10 days')
+        df_cv1 = diagnostics.cross_validation(m, horizon="32 days", period="10 days")
         df_cv2 = diagnostics.cross_validation(
-            m, horizon='32 days', period='10 days', initial='96 days')
-        self.assertAlmostEqual(
-            ((df_cv1['y'] - df_cv2['y']) ** 2).sum(), 0.0)
-        self.assertAlmostEqual(
-            ((df_cv1['yhat'] - df_cv2['yhat']) ** 2).sum(), 0.0)
+            m, horizon="32 days", period="10 days", initial="96 days"
+        )
+        assert ((df_cv1["y"] - df_cv2["y"]) ** 2).sum() == pytest.approx(0.0)
+        assert ((df_cv1["yhat"] - df_cv2["yhat"]) ** 2).sum() == pytest.approx(0.0)
 
-    def test_cross_validation_custom_cutoffs(self):
-        m = Prophet()
-        m.fit(self.__df)
+    def test_cross_validation_custom_cutoffs(self, ts_short, backend):
+        m = Prophet(stan_backend=backend)
+        m.fit(ts_short)
         # When specify a list of cutoffs
         #  the cutoff dates in df_cv are those specified
         df_cv1 = diagnostics.cross_validation(
             m,
-            horizon='32 days',
-            period='10 days',
-            cutoffs=[pd.Timestamp('2012-07-31'), pd.Timestamp('2012-08-31')])
-        self.assertEqual(len(df_cv1['cutoff'].unique()), 2)
+            horizon="32 days",
+            period="10 days",
+            cutoffs=[pd.Timestamp("2012-07-31"), pd.Timestamp("2012-08-31")],
+        )
+        assert len(df_cv1["cutoff"].unique()) == 2
 
-    def test_cross_validation_uncertainty_disabled(self):
-        df = self.__df.copy()
+    def test_cross_validation_uncertainty_disabled(self, ts_short, backend):
+        df = ts_short.copy()
         for uncertainty in [0, False]:
-            m = Prophet(uncertainty_samples=uncertainty)
-            m.fit(df, algorithm='Newton')
+            m = Prophet(uncertainty_samples=uncertainty, stan_backend=backend)
+            m.fit(df, algorithm="Newton")
             df_cv = diagnostics.cross_validation(
-                m, horizon='4 days', period='4 days', initial='115 days')
-            expected_cols = ['ds', 'yhat', 'y', 'cutoff']
-            self.assertTrue(all(col in expected_cols for col in df_cv.columns.tolist()))
+                m, horizon="4 days", period="4 days", initial="115 days"
+            )
+            expected_cols = ["ds", "yhat", "y", "cutoff"]
+            assert all(col in expected_cols for col in df_cv.columns.tolist())
             df_p = diagnostics.performance_metrics(df_cv)
-            self.assertTrue('coverage' not in df_p.columns)
+            assert "coverage" not in df_p.columns
 
-    def test_performance_metrics(self):
-        m = Prophet()
-        m.fit(self.__df)
+
+class TestPerformanceMetrics:
+    def test_performance_metrics(self, ts_short, backend):
+        m = Prophet(stan_backend=backend)
+        m.fit(ts_short)
         df_cv = diagnostics.cross_validation(
-            m, horizon='4 days', period='10 days', initial='90 days')
+            m, horizon="4 days", period="10 days", initial="90 days"
+        )
         # Aggregation level none
         df_none = diagnostics.performance_metrics(df_cv, rolling_window=-1)
-        self.assertEqual(
-            set(df_none.columns),
-            {'horizon', 'coverage', 'mae', 'mape', 'mdape', 'mse', 'rmse', 'smape'},
-        )
-        self.assertEqual(df_none.shape[0], 16)
+        assert set(df_none.columns) == {
+            "horizon",
+            "coverage",
+            "mae",
+            "mape",
+            "mdape",
+            "mse",
+            "rmse",
+            "smape",
+        }
+        assert df_none.shape[0] == 16
         # Aggregation level 0
         df_0 = diagnostics.performance_metrics(df_cv, rolling_window=0)
-        self.assertEqual(len(df_0), 4)
-        self.assertEqual(len(df_0['horizon'].unique()), 4)
+        assert len(df_0) == 4
+        assert len(df_0["horizon"].unique()) == 4
         # Aggregation level 0.2
         df_horizon = diagnostics.performance_metrics(df_cv, rolling_window=0.2)
-        self.assertEqual(len(df_horizon), 4)
-        self.assertEqual(len(df_horizon['horizon'].unique()), 4)
+        assert len(df_horizon) == 4
+        assert len(df_horizon["horizon"].unique()) == 4
         # Aggregation level all
         df_all = diagnostics.performance_metrics(df_cv, rolling_window=1)
-        self.assertEqual(df_all.shape[0], 1)
-        for metric in ['mse', 'mape', 'mae', 'coverage']:
-            self.assertAlmostEqual(df_all[metric].values[0], df_none[metric].mean())
-        self.assertAlmostEqual(df_all['mdape'].values[0], df_none['mdape'].median())
+        assert df_all.shape[0] == 1
+        for metric in ["mse", "mape", "mae", "coverage"]:
+            assert df_all[metric].values[0] == pytest.approx(df_none[metric].mean())
+        assert df_all["mdape"].values[0] == pytest.approx(df_none["mdape"].median())
         # Custom list of metrics
         df_horizon = diagnostics.performance_metrics(
-            df_cv, metrics=['coverage', 'mse'],
+            df_cv,
+            metrics=["coverage", "mse"],
         )
-        self.assertEqual(
-            set(df_horizon.columns),
-            {'coverage', 'mse', 'horizon'},
-        )
+        assert set(df_horizon.columns) == {"coverage", "mse", "horizon"}
         # Skip MAPE
-        df_cv.loc[0, 'y'] = 0.
+        df_cv.loc[0, "y"] = 0.0
         df_horizon = diagnostics.performance_metrics(
-            df_cv, metrics=['coverage', 'mape'],
+            df_cv,
+            metrics=["coverage", "mape"],
         )
-        self.assertEqual(
-            set(df_horizon.columns),
-            {'coverage', 'horizon'},
-        )
+        assert set(df_horizon.columns) == {"coverage", "horizon"}
         df_horizon = diagnostics.performance_metrics(
-            df_cv, metrics=['mape'],
+            df_cv,
+            metrics=["mape"],
         )
-        self.assertIsNone(df_horizon)
+        assert df_horizon is None
         # List of metrics containing non-valid metrics
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             diagnostics.performance_metrics(
-                df_cv, metrics=['mse', 'error_metric'],
+                df_cv,
+                metrics=["mse", "error_metric"],
             )
 
     def test_rolling_mean(self):
         x = np.arange(10)
         h = np.arange(10)
-        df = diagnostics.rolling_mean_by_h(x=x, h=h, w=1, name='x')
-        self.assertTrue(np.array_equal(x, df['x'].values))
-        self.assertTrue(np.array_equal(h, df['horizon'].values))
+        df = diagnostics.rolling_mean_by_h(x=x, h=h, w=1, name="x")
+        assert np.array_equal(x, df["x"].values)
+        assert np.array_equal(h, df["horizon"].values)
 
-        df = diagnostics.rolling_mean_by_h(x, h, w=4, name='x')
-        self.assertTrue(np.allclose(x[3:] - 1.5, df['x'].values))
-        self.assertTrue(np.array_equal(np.arange(3, 10), df['horizon'].values))
+        df = diagnostics.rolling_mean_by_h(x, h, w=4, name="x")
+        assert np.allclose(x[3:] - 1.5, df["x"].values)
+        assert np.array_equal(np.arange(3, 10), df["horizon"].values)
 
-        h = np.array([1., 2., 3., 4., 4., 4., 4., 4., 7., 7.])
-        x_true = np.array([1.0, 5.0 , 22. / 3])
-        h_true = np.array([3., 4., 7.])
-        df = diagnostics.rolling_mean_by_h(x, h, w=3, name='x')
-        self.assertTrue(np.allclose(x_true, df['x'].values))
-        self.assertTrue(np.array_equal(h_true, df['horizon'].values))
+        h = np.array([1.0, 2.0, 3.0, 4.0, 4.0, 4.0, 4.0, 4.0, 7.0, 7.0])
+        x_true = np.array([1.0, 5.0, 22.0 / 3])
+        h_true = np.array([3.0, 4.0, 7.0])
+        df = diagnostics.rolling_mean_by_h(x, h, w=3, name="x")
+        assert np.allclose(x_true, df["x"].values)
+        assert np.array_equal(h_true, df["horizon"].values)
 
-        df = diagnostics.rolling_mean_by_h(x, h, w=10, name='x')
-        self.assertTrue(np.allclose(np.array([7.]), df['horizon'].values))
-        self.assertTrue(np.allclose(np.array([4.5]), df['x'].values))
+        df = diagnostics.rolling_mean_by_h(x, h, w=10, name="x")
+        assert np.allclose(np.array([7.0]), df["horizon"].values)
+        assert np.allclose(np.array([4.5]), df["x"].values)
 
     def test_rolling_median(self):
         x = np.arange(10)
         h = np.arange(10)
-        df = diagnostics.rolling_median_by_h(x=x, h=h, w=1, name='x')
-        self.assertTrue(np.array_equal(x, df['x'].values))
-        self.assertTrue(np.array_equal(h, df['horizon'].values))
+        df = diagnostics.rolling_median_by_h(x=x, h=h, w=1, name="x")
+        assert np.array_equal(x, df["x"].values)
+        assert np.array_equal(h, df["horizon"].values)
 
-        df = diagnostics.rolling_median_by_h(x, h, w=4, name='x')
+        df = diagnostics.rolling_median_by_h(x, h, w=4, name="x")
         x_true = x[3:] - 1.5
-        self.assertTrue(np.allclose(x_true, df['x'].values))
-        self.assertTrue(np.array_equal(np.arange(3, 10), df['horizon'].values))
+        assert np.allclose(x_true, df["x"].values)
+        assert np.array_equal(np.arange(3, 10), df["horizon"].values)
 
-        h = np.array([1., 2., 3., 4., 4., 4., 4., 4., 7., 7.])
+        h = np.array([1.0, 2.0, 3.0, 4.0, 4.0, 4.0, 4.0, 4.0, 7.0, 7.0])
         x_true = np.array([1.0, 5.0, 8.0])
-        h_true = np.array([3., 4., 7.])
-        df = diagnostics.rolling_median_by_h(x, h, w=3, name='x')
-        self.assertTrue(np.allclose(x_true, df['x'].values))
-        self.assertTrue(np.array_equal(h_true, df['horizon'].values))
+        h_true = np.array([3.0, 4.0, 7.0])
+        df = diagnostics.rolling_median_by_h(x, h, w=3, name="x")
+        assert np.allclose(x_true, df["x"].values)
+        assert np.array_equal(h_true, df["horizon"].values)
 
-        df = diagnostics.rolling_median_by_h(x, h, w=10, name='x')
-        self.assertTrue(np.allclose(np.array([7.]), df['horizon'].values))
-        self.assertTrue(np.allclose(np.array([4.5]), df['x'].values))
+        df = diagnostics.rolling_median_by_h(x, h, w=10, name="x")
+        assert np.allclose(np.array([7.0]), df["horizon"].values)
+        assert np.allclose(np.array([4.5]), df["x"].values)
 
-    def test_copy(self):
-        df = DATA_all.copy()
-        df['cap'] = 200.
-        df['binary_feature'] = [0] * 255 + [1] * 255
+
+class TestProphetCopy:
+    @pytest.fixture(scope="class")
+    def data(self, daily_univariate_ts):
+        df = daily_univariate_ts.copy()
+        df["cap"] = 200.0
+        df["binary_feature"] = [0] * 255 + [1] * 255
+        return df
+
+    def test_prophet_copy(self, data, backend):
         # These values are created except for its default values
-        holiday = pd.DataFrame(
-            {'ds': pd.to_datetime(['2016-12-25']), 'holiday': ['x']})
+        holiday = pd.DataFrame({"ds": pd.to_datetime(["2016-12-25"]), "holiday": ["x"]})
         products = itertools.product(
-            ['linear', 'logistic'],  # growth
-            [None, pd.to_datetime(['2016-12-25'])],  # changepoints
+            ["linear", "logistic"],  # growth
+            [None, pd.to_datetime(["2016-12-25"])],  # changepoints
             [3],  # n_changepoints
             [0.9],  # changepoint_range
             [True, False],  # yearly_seasonality
             [True, False],  # weekly_seasonality
             [True, False],  # daily_seasonality
             [None, holiday],  # holidays
-            ['additive', 'multiplicative'],  # seasonality_mode
+            ["additive", "multiplicative"],  # seasonality_mode
             [1.1],  # seasonality_prior_scale
             [1.1],  # holidays_prior_scale
             [0.1],  # changepoint_prior_scale
             [100],  # mcmc_samples
             [0.9],  # interval_width
-            [200]  # uncertainty_samples
+            [200],  # uncertainty_samples
         )
         # Values should be copied correctly
         for product in products:
-            m1 = Prophet(*product)
-            m1.country_holidays = 'US'
-            m1.history = m1.setup_dataframe(
-                df.copy(), initialize_scales=True)
+            m1 = Prophet(*product, stan_backend=backend)
+            m1.country_holidays = "US"
+            m1.history = m1.setup_dataframe(data.copy(), initialize_scales=True)
             m1.set_auto_seasonalities()
             m2 = diagnostics.prophet_copy(m1)
-            self.assertEqual(m1.growth, m2.growth)
-            self.assertEqual(m1.n_changepoints, m2.n_changepoints)
-            self.assertEqual(m1.changepoint_range, m2.changepoint_range)
+            assert m1.growth == m2.growth
+            assert m1.n_changepoints == m2.n_changepoints
+            assert m1.changepoint_range == m2.changepoint_range
             if m1.changepoints is None:
-                self.assertEqual(m1.changepoints, m2.changepoints)
+                assert m1.changepoints == m2.changepoints
             else:
-                self.assertTrue(m1.changepoints.equals(m2.changepoints))
-            self.assertEqual(False, m2.yearly_seasonality)
-            self.assertEqual(False, m2.weekly_seasonality)
-            self.assertEqual(False, m2.daily_seasonality)
-            self.assertEqual(
-                m1.yearly_seasonality, 'yearly' in m2.seasonalities)
-            self.assertEqual(
-                m1.weekly_seasonality, 'weekly' in m2.seasonalities)
-            self.assertEqual(
-                m1.daily_seasonality, 'daily' in m2.seasonalities)
+                assert m1.changepoints.equals(m2.changepoints)
+            assert False == m2.yearly_seasonality
+            assert False == m2.weekly_seasonality
+            assert False == m2.daily_seasonality
+            assert m1.yearly_seasonality == ("yearly" in m2.seasonalities)
+            assert m1.weekly_seasonality == ("weekly" in m2.seasonalities)
+            assert m1.daily_seasonality == ("daily" in m2.seasonalities)
             if m1.holidays is None:
-                self.assertEqual(m1.holidays, m2.holidays)
+                assert m1.holidays == m2.holidays
             else:
-                self.assertTrue((m1.holidays == m2.holidays).values.all())
-            self.assertEqual(m1.country_holidays, m2.country_holidays)
-            self.assertEqual(m1.seasonality_mode, m2.seasonality_mode)
-            self.assertEqual(m1.seasonality_prior_scale,
-                             m2.seasonality_prior_scale)
-            self.assertEqual(m1.changepoint_prior_scale,
-                             m2.changepoint_prior_scale)
-            self.assertEqual(m1.holidays_prior_scale, m2.holidays_prior_scale)
-            self.assertEqual(m1.mcmc_samples, m2.mcmc_samples)
-            self.assertEqual(m1.interval_width, m2.interval_width)
-            self.assertEqual(m1.uncertainty_samples, m2.uncertainty_samples)
+                assert (m1.holidays == m2.holidays).values.all()
+            assert m1.country_holidays == m2.country_holidays
+            assert m1.seasonality_mode == m2.seasonality_mode
+            assert m1.seasonality_prior_scale == m2.seasonality_prior_scale
+            assert m1.changepoint_prior_scale == m2.changepoint_prior_scale
+            assert m1.holidays_prior_scale == m2.holidays_prior_scale
+            assert m1.mcmc_samples == m2.mcmc_samples
+            assert m1.interval_width == m2.interval_width
+            assert m1.uncertainty_samples == m2.uncertainty_samples
 
-        # Check for cutoff and custom seasonality and extra regressors
-        changepoints = pd.date_range('2012-06-15', '2012-09-15')
-        cutoff = pd.Timestamp('2012-07-25')
-        m1 = Prophet(changepoints=changepoints)
-        m1.add_seasonality('custom', 10, 5)
-        m1.add_regressor('binary_feature')
-        m1.fit(df)
+    def test_prophet_copy_custom(self, data, backend):
+        changepoints = pd.date_range("2012-06-15", "2012-09-15")
+        cutoff = pd.Timestamp("2012-07-25")
+        m1 = Prophet(changepoints=changepoints, stan_backend=backend)
+        m1.add_seasonality("custom", 10, 5)
+        m1.add_regressor("binary_feature")
+        m1.fit(data)
         m2 = diagnostics.prophet_copy(m1, cutoff=cutoff)
         changepoints = changepoints[changepoints < cutoff]
-        self.assertTrue((changepoints == m2.changepoints).all())
-        self.assertTrue('custom' in m2.seasonalities)
-        self.assertTrue('binary_feature' in m2.extra_regressors)
-
+        assert (changepoints == m2.changepoints).all()
+        assert "custom" in m2.seasonalities
+        assert "binary_feature" in m2.extra_regressors

--- a/python/prophet/tests/test_prophet.py
+++ b/python/prophet/tests/test_prophet.py
@@ -3,359 +3,268 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-import os
-from unittest import TestCase
-
 import numpy as np
 import pandas as pd
 import pytest
+
 from prophet import Prophet
 from prophet.utilities import warm_start_params
 
 
-DATA = pd.read_csv(
-    os.path.join(os.path.dirname(__file__), 'data.csv'),
-    parse_dates=['ds'],
-)
-DATA2 = pd.read_csv(
-    os.path.join(os.path.dirname(__file__), 'data2.csv'),
-    parse_dates=['ds'],
-)
+def train_test_split(ts_data: pd.DataFrame, n_test_rows: int) -> pd.DataFrame:
+    train = ts_data.head(ts_data.shape[0] - n_test_rows)
+    test = ts_data.tail(n_test_rows)
+    return train.reset_index(), test.reset_index()
 
 
-class TestProphet(TestCase):
+def rmse(predictions, targets) -> float:
+    return np.sqrt(np.mean((predictions - targets) ** 2))
 
-    @staticmethod
-    def rmse(predictions, targets):
-        return np.sqrt(np.mean((predictions - targets) ** 2))
 
-    def test_fit_predict(self):
-        days = 30
-        N = DATA.shape[0]
-        train = DATA.head(N - days)
-        test = DATA.tail(days)
-        test.reset_index(inplace=True)
-
-        forecaster = Prophet()
+class TestProphetFitPredictDefault:
+    def test_fit_predict(self, daily_univariate_ts, backend):
+        test_days = 30
+        train, test = train_test_split(daily_univariate_ts, test_days)
+        forecaster = Prophet(stan_backend=backend)
         forecaster.fit(train, seed=1237861298)
         np.random.seed(876543987)
-        future = forecaster.make_future_dataframe(days, include_history=False)
+        future = forecaster.make_future_dataframe(test_days, include_history=False)
         future = forecaster.predict(future)
+        res = rmse(future["yhat"], test["y"])
         # this gives ~ 10.64
-        res = self.rmse(future['yhat'], test['y'])
-        self.assertTrue(15 > res > 5, msg="backend: {}".format(forecaster.stan_backend))
+        assert 15 > res > 5, "backend: {}".format(forecaster.stan_backend)
 
-    def test_fit_predict_newton(self):
-        days = 30
-        N = DATA.shape[0]
-        train = DATA.head(N - days)
-        test = DATA.tail(days)
-        test.reset_index(inplace=True)
-
-        forecaster = Prophet()
-        forecaster.fit(train, seed=1237861298, algorithm='Newton')
+    def test_fit_predict_newton(self, daily_univariate_ts, backend):
+        test_days = 30
+        train, test = train_test_split(daily_univariate_ts, test_days)
+        forecaster = Prophet(stan_backend=backend)
+        forecaster.fit(train, algorithm="Newton", seed=1237861298)
         np.random.seed(876543987)
-        future = forecaster.make_future_dataframe(days, include_history=False)
+        future = forecaster.make_future_dataframe(test_days, include_history=False)
         future = forecaster.predict(future)
         # this gives ~ 10.64
-        res = self.rmse(future['yhat'], test['y'])
-        self.assertAlmostEqual(res, 23.44, places=2, msg="backend: {}".format(forecaster.stan_backend))
+        res = rmse(future["yhat"], test["y"])
+        assert res == pytest.approx(23.44, 0.01), "backend: {}".format(forecaster.stan_backend)
 
     @pytest.mark.slow
-    def test_fit_sampling_predict(self):
-        days = 30
-        N = DATA.shape[0]
-        train = DATA.head(N - days)
-        test = DATA.tail(days)
-        test.reset_index(inplace=True)
-
-        forecaster = Prophet(mcmc_samples=500)
-
+    def test_fit_predict_sampling(self, daily_univariate_ts, backend):
+        test_days = 30
+        train, test = train_test_split(daily_univariate_ts, test_days)
+        forecaster = Prophet(mcmc_samples=500, stan_backend=backend)
         # chains adjusted from 4 to 7 to satisfy test for cmdstanpy
         forecaster.fit(train, seed=1237861298, chains=7, show_progress=False)
         np.random.seed(876543987)
-        future = forecaster.make_future_dataframe(days, include_history=False)
+        future = forecaster.make_future_dataframe(test_days, include_history=False)
         future = forecaster.predict(future)
         # this gives ~ 215.77
-        res = self.rmse(future['yhat'], test['y'])
-        self.assertTrue(236 > res > 193, msg="backend: {}".format(forecaster.stan_backend))
+        res = rmse(future["yhat"], test["y"])
+        assert 236 < res < 193, "backend: {}".format(forecaster.stan_backend)
 
-    def test_fit_predict_no_seasons(self):
-        N = DATA.shape[0]
-        train = DATA.head(N // 2)
-        periods = 30
-
-        forecaster = Prophet(weekly_seasonality=False,
-                             yearly_seasonality=False)
+    def test_fit_predict_no_seasons(self, daily_univariate_ts, backend):
+        test_days = 30
+        train, _ = train_test_split(daily_univariate_ts, test_days)
+        forecaster = Prophet(
+            weekly_seasonality=False, yearly_seasonality=False, stan_backend=backend
+        )
         forecaster.fit(train)
-        future = forecaster.make_future_dataframe(periods=periods, include_history=False)
+        future = forecaster.make_future_dataframe(test_days, include_history=False)
         result = forecaster.predict(future)
-        self.assertTrue((future.ds == result.ds).all())
+        assert (future.ds == result.ds).all()
 
-    def test_fit_predict_no_changepoints(self):
-        N = DATA.shape[0]
-        train = DATA.head(N // 2)
-        future = DATA.tail(N // 2)
-
-        forecaster = Prophet(n_changepoints=0)
+    def test_fit_predict_no_changepoints(self, daily_univariate_ts, backend):
+        test_days = daily_univariate_ts.shape[0] // 2
+        train, future = train_test_split(daily_univariate_ts, test_days)
+        forecaster = Prophet(n_changepoints=0, stan_backend=backend)
         forecaster.fit(train)
         forecaster.predict(future)
+        assert forecaster.params is not None
+        assert forecaster.n_changepoints == 0
 
     @pytest.mark.slow
-    def test_fit_predict_no_changepoints_mcmc(self):
-        N = DATA.shape[0]
-        train = DATA.head(N // 2)
-        future = DATA.tail(N // 2)
-
-        forecaster = Prophet(n_changepoints=0, mcmc_samples=100)
+    def test_fit_predict_no_changepoints_mcmc(self, daily_univariate_ts, backend):
+        test_days = daily_univariate_ts.shape[0] // 2
+        train, future = train_test_split(daily_univariate_ts, test_days)
+        forecaster = Prophet(n_changepoints=0, mcmc_samples=100, stan_backend=backend)
         forecaster.fit(train, show_progress=False)
         forecaster.predict(future)
+        assert forecaster.params is not None
+        assert forecaster.n_changepoints == 0
 
-    def test_fit_changepoint_not_in_history(self):
-        train = DATA[(DATA['ds'] < '2013-01-01') | (DATA['ds'] > '2014-01-01')]
-        future = pd.DataFrame({'ds': DATA['ds']})
-        prophet = Prophet(changepoints=['2013-06-06'])
+    def test_fit_changepoint_not_in_history(self, daily_univariate_ts, backend):
+        train = daily_univariate_ts[
+            (daily_univariate_ts["ds"] < "2013-01-01") | (daily_univariate_ts["ds"] > "2014-01-01")
+        ]
+        future = pd.DataFrame({"ds": daily_univariate_ts["ds"]})
+        prophet = Prophet(changepoints=["2013-06-06"], stan_backend=backend)
         forecaster = prophet
         forecaster.fit(train)
         forecaster.predict(future)
+        assert forecaster.params is not None
+        assert forecaster.n_changepoints == 1
 
-    def test_fit_predict_duplicates(self):
-        N = DATA.shape[0]
-        train1 = DATA.head(N // 2).copy()
-        train2 = DATA.head(N // 2).copy()
-        train2['y'] += 10
-        train = pd.concat([train1, train2])
-        future = pd.DataFrame({'ds': DATA['ds'].tail(N // 2)})
-        forecaster = Prophet()
+    def test_fit_predict_duplicates(self, daily_univariate_ts, backend):
+        """
+        The underlying model should still fit successfully when there are duplicate dates in the history.
+        The model essentially sees this as multiple observations for the same time value, and fits the parameters
+        accordingly.
+        """
+        train, test = train_test_split(daily_univariate_ts, daily_univariate_ts.shape[0] // 2)
+        repeated_obs = train.copy()
+        repeated_obs["y"] += 10
+        train = pd.concat([train, repeated_obs])
+        forecaster = Prophet(stan_backend=backend)
         forecaster.fit(train)
-        forecaster.predict(future)
+        forecaster.predict(test)
 
-    def test_fit_predict_constant_history(self):
-        N = DATA.shape[0]
-        train = DATA.head(N // 2).copy()
-        train['y'] = 20
-        future = pd.DataFrame({'ds': DATA['ds'].tail(N // 2)})
-        m = Prophet()
-        m.fit(train)
-        fcst = m.predict(future)
-        self.assertEqual(fcst['yhat'].values[-1], 20)
-        train['y'] = 0
-        future = pd.DataFrame({'ds': DATA['ds'].tail(N // 2)})
-        m = Prophet()
-        m.fit(train)
-        fcst = m.predict(future)
-        self.assertEqual(fcst['yhat'].values[-1], 0)
+    def test_fit_predict_constant_history(self, daily_univariate_ts, backend):
+        """
+        When the training data history is constant, Prophet should predict the same value for all future dates.
+        """
+        for constant in [0, 20]:
+            train, test = train_test_split(daily_univariate_ts, daily_univariate_ts.shape[0] // 2)
+            train["y"] = constant
+            forecaster = Prophet(stan_backend=backend)
+            forecaster.fit(train)
+            result = forecaster.predict(test)
+            assert result["yhat"].values[-1] == constant
 
-    def test_fit_predict_uncertainty_disabled(self):
-        N = DATA.shape[0]
-        train = DATA.head(N // 2)
-        future = DATA.tail(N // 2)
-
+    def test_fit_predict_uncertainty_disabled(self, daily_univariate_ts, backend):
+        test_days = daily_univariate_ts.shape[0] // 2
+        train, future = train_test_split(daily_univariate_ts, test_days)
         for uncertainty in [0, False]:
-            m = Prophet(uncertainty_samples=uncertainty)
-            m.fit(train)
-            fcst = m.predict(future)
-            expected_cols = ['ds', 'trend', 'additive_terms',
-                             'multiplicative_terms', 'weekly', 'yhat']
-            self.assertTrue(all(col in expected_cols
-                                for col in fcst.columns.tolist()))
+            forecaster = Prophet(uncertainty_samples=uncertainty, stan_backend=backend)
+            forecaster.fit(train)
+            result = forecaster.predict(future)
+            expected_cols = [
+                "ds",
+                "trend",
+                "additive_terms",
+                "multiplicative_terms",
+                "weekly",
+                "yhat",
+            ]
+            assert all(col in expected_cols for col in result.columns.tolist())
 
-    def test_setup_dataframe(self):
-        m = Prophet()
-        N = DATA.shape[0]
-        history = DATA.head(N // 2).copy()
 
-        history = m.setup_dataframe(history, initialize_scales=True)
+class TestProphetDataPrep:
+    def test_setup_dataframe(self, daily_univariate_ts, backend):
+        """Test that the columns 't' and 'y_scaled' are added to the dataframe."""
+        train, _ = train_test_split(daily_univariate_ts, daily_univariate_ts.shape[0] // 2)
+        m = Prophet(stan_backend=backend)
+        history = m.setup_dataframe(train, initialize_scales=True)
 
-        self.assertTrue('t' in history)
-        self.assertEqual(history['t'].min(), 0.0)
-        self.assertEqual(history['t'].max(), 1.0)
+        assert "t" in history
+        assert history["t"].min() == 0.0
+        assert history["t"].max() == 1.0
 
-        self.assertTrue('y_scaled' in history)
-        self.assertEqual(history['y_scaled'].max(), 1.0)
+        assert "y_scaled" in history
+        assert history["y_scaled"].max() == 1.0
 
-    def test_setup_dataframe_ds_column(self):
-        "Test case where 'ds' exists as an index name and column"
-        df = DATA.copy()
-        df.index = df.loc[:, 'ds']
-        m = Prophet()
-        m.fit(df)
+    def test_setup_dataframe_ds_column(self, daily_univariate_ts, backend):
+        """Test case where 'ds' exists as an index name and column. Prophet should use the column."""
+        train, _ = train_test_split(daily_univariate_ts, daily_univariate_ts.shape[0] // 2)
+        train.index = pd.to_datetime(["1970-01-01" for _ in range(train.shape[0])])
+        train.index.rename("ds", inplace=True)
+        m = Prophet(stan_backend=backend)
+        m.fit(train)
+        assert np.all(m.history["ds"].values == train["ds"].values)
 
-    def test_logistic_floor(self):
-        m = Prophet(growth='logistic')
-        N = DATA.shape[0]
-        history = DATA.head(N // 2).copy()
-        history['floor'] = 10.
-        history['cap'] = 80.
-        future = DATA.tail(N // 2).copy()
-        future['cap'] = 80.
-        future['floor'] = 10.
-        m.fit(history, algorithm='Newton')
-        self.assertTrue(m.logistic_floor)
-        self.assertTrue('floor' in m.history)
-        self.assertAlmostEqual(m.history['y_scaled'][0], 1.)
-        self.assertEqual(m.fit_kwargs, {'algorithm': 'Newton'})
-        fcst1 = m.predict(future)
+    def test_logistic_floor(self, daily_univariate_ts, backend):
+        """Test the scaling of y with logistic growth and a floor/cap."""
+        train, _ = train_test_split(daily_univariate_ts, daily_univariate_ts.shape[0] // 2)
+        train["floor"] = 10.0
+        train["cap"] = 80.0
+        m = Prophet(growth="logistic", stan_backend=backend)
+        m.fit(train)
+        assert m.logistic_floor
+        assert "floor" in m.history
+        assert m.history["y_scaled"][0] == 1.0
+        for col in ["y", "floor", "cap"]:
+            train[col] += 10.0
+        m2 = Prophet(growth="logistic", stan_backend=backend)
+        m2.fit(train)
+        assert m2.history["y_scaled"][0] == pytest.approx(1.0, 0.01)
 
-        m2 = Prophet(growth='logistic')
-        history2 = history.copy()
-        history2['y'] += 10.
-        history2['floor'] += 10.
-        history2['cap'] += 10.
-        future['cap'] += 10.
-        future['floor'] += 10.
-        m2.fit(history2, algorithm='Newton')
-        self.assertAlmostEqual(m2.history['y_scaled'][0], 1.)
+    def test_make_future_dataframe(self, daily_univariate_ts, backend):
+        train = daily_univariate_ts.head(468 // 2)
+        forecaster = Prophet(stan_backend=backend)
+        forecaster.fit(train)
+        future = forecaster.make_future_dataframe(periods=3, freq="D", include_history=False)
+        correct = pd.DatetimeIndex(["2013-04-26", "2013-04-27", "2013-04-28"])
+        assert len(future) == 3
+        assert np.all(future["ds"].values == correct.values)
 
-    def test_flat_growth(self):
-        m = Prophet(growth='flat')
+        future = forecaster.make_future_dataframe(periods=3, freq="M", include_history=False)
+        correct = pd.DatetimeIndex(["2013-04-30", "2013-05-31", "2013-06-30"])
+        assert len(future) == 3
+        assert np.all(future["ds"].values == correct.values)
+
+
+class TestProphetTrendComponent:
+    def test_invalid_growth_input(self, backend):
+        msg = 'Parameter "growth" should be "linear", ' '"logistic" or "flat".'
+        with pytest.raises(ValueError, match=msg):
+            Prophet(growth="constant", stan_backend=backend)
+
+    def test_growth_init(self, daily_univariate_ts, backend):
+        model = Prophet(growth="logistic", stan_backend=backend)
+        train = daily_univariate_ts.iloc[:468].copy()
+        train["cap"] = train["y"].max()
+
+        history = model.setup_dataframe(train, initialize_scales=True)
+
+        k, m = model.linear_growth_init(history)
+        assert k == pytest.approx(0.3055671)
+        assert m == pytest.approx(0.5307511)
+
+        k, m = model.logistic_growth_init(history)
+        assert k == pytest.approx(1.507925, abs=1e-4)
+        assert m == pytest.approx(-0.08167497, abs=1e-4)
+
+        k, m = model.flat_growth_init(history)
+        assert k == 0
+        assert m == pytest.approx(0.49335657, abs=1e-4)
+
+    def test_flat_growth(self, backend):
+        m = Prophet(growth="flat", stan_backend=backend)
         x = np.linspace(0, 2 * np.pi, 8 * 7)
-        history = pd.DataFrame({
-            'ds': pd.date_range(start='2020-01-01', periods=8 * 7, freq='d'),
-            'y': 30 + np.sin(x * 8.),
-        })
+        history = pd.DataFrame(
+            {
+                "ds": pd.date_range(start="2020-01-01", periods=8 * 7, freq="d"),
+                "y": 30 + np.sin(x * 8.0),
+            }
+        )
         m.fit(history)
         future = m.make_future_dataframe(10, include_history=True)
         fcst = m.predict(future)
-        m_ = m.params['m'][0, 0]
-        k = m.params['k'][0, 0]
-        self.assertAlmostEqual(k, 0)
-        self.assertAlmostEqual(fcst['trend'].unique()[0], m_ * m.y_scale)
-        self.assertEqual(np.round(m_ * m.y_scale), 30.0)
+        m_ = m.params["m"][0, 0]
+        k = m.params["k"][0, 0]
+        assert k == pytest.approx(0.0)
+        assert fcst["trend"].unique()[0] == pytest.approx(m_ * m.y_scale)
+        assert np.round(m_ * m.y_scale) == 30.0
 
-    def test_invalid_growth_input(self):
-        msg = 'Parameter "growth" should be "linear", ' \
-              '"logistic" or "flat".'
-        with self.assertRaisesRegex(ValueError, msg):
-            Prophet(growth="constant")
+    def test_piecewise_linear(self, backend):
+        model = Prophet(stan_backend=backend)
 
-    def test_get_changepoints(self):
-            m = Prophet()
-            N = DATA.shape[0]
-            history = DATA.head(N // 2).copy()
-
-            history = m.setup_dataframe(history, initialize_scales=True)
-            m.history = history
-
-            m.set_changepoints()
-
-            cp = m.changepoints_t
-            self.assertEqual(cp.shape[0], m.n_changepoints)
-            self.assertEqual(len(cp.shape), 1)
-            self.assertTrue(cp.min() > 0)
-            cp_indx = int(np.ceil(0.8 * history.shape[0]))
-            self.assertTrue(cp.max() <= history['t'].values[cp_indx])
-
-    def test_set_changepoint_range(self):
-        m = Prophet(changepoint_range=0.4)
-        N = DATA.shape[0]
-        history = DATA.head(N // 2).copy()
-
-        history = m.setup_dataframe(history, initialize_scales=True)
-        m.history = history
-
-        m.set_changepoints()
-
-        cp = m.changepoints_t
-        self.assertEqual(cp.shape[0], m.n_changepoints)
-        self.assertEqual(len(cp.shape), 1)
-        self.assertTrue(cp.min() > 0)
-        cp_indx = int(np.ceil(0.4 * history.shape[0]))
-        self.assertTrue(cp.max() <= history['t'].values[cp_indx])
-        with self.assertRaises(ValueError):
-            m = Prophet(changepoint_range=-0.1)
-        with self.assertRaises(ValueError):
-            m = Prophet(changepoint_range=2)
-
-    def test_get_zero_changepoints(self):
-        m = Prophet(n_changepoints=0)
-        N = DATA.shape[0]
-        history = DATA.head(N // 2).copy()
-
-        history = m.setup_dataframe(history, initialize_scales=True)
-        m.history = history
-
-        m.set_changepoints()
-        cp = m.changepoints_t
-        self.assertEqual(cp.shape[0], 1)
-        self.assertEqual(cp[0], 0)
-
-    def test_override_n_changepoints(self):
-        m = Prophet()
-        history = DATA.head(20).copy()
-
-        history = m.setup_dataframe(history, initialize_scales=True)
-        m.history = history
-
-        m.set_changepoints()
-        self.assertEqual(m.n_changepoints, 15)
-        cp = m.changepoints_t
-        self.assertEqual(cp.shape[0], 15)
-
-    def test_fourier_series_weekly(self):
-        mat = Prophet.fourier_series(DATA['ds'], 7, 3)
-        # These are from the R forecast package directly.
-        true_values = np.array([
-            0.7818315, 0.6234898, 0.9749279, -0.2225209, 0.4338837, -0.9009689
-        ])
-        self.assertAlmostEqual(np.sum((mat[0] - true_values) ** 2), 0.0)
-
-    def test_fourier_series_yearly(self):
-        mat = Prophet.fourier_series(DATA['ds'], 365.25, 3)
-        # These are from the R forecast package directly.
-        true_values = np.array([
-            0.7006152, -0.7135393, -0.9998330, 0.01827656, 0.7262249, 0.6874572
-        ])
-        self.assertAlmostEqual(np.sum((mat[0] - true_values) ** 2), 0.0)
-
-    def test_growth_init(self):
-        model = Prophet(growth='logistic')
-        history = DATA.iloc[:468].copy()
-        history['cap'] = history['y'].max()
-
-        history = model.setup_dataframe(history, initialize_scales=True)
-
-        k, m = model.linear_growth_init(history)
-        self.assertAlmostEqual(k, 0.3055671)
-        self.assertAlmostEqual(m, 0.5307511)
-
-        k, m = model.logistic_growth_init(history)
-
-        self.assertAlmostEqual(k, 1.507925, places=4)
-        self.assertAlmostEqual(m, -0.08167497, places=4)
-
-        k,m = model.flat_growth_init(history)
-        self.assertEqual(k, 0)
-        self.assertAlmostEqual(m,  0.49335657, places=4)
-
-    def test_piecewise_linear(self):
-        model = Prophet()
-
-        t = np.arange(11.)
+        t = np.arange(11.0)
         m = 0
         k = 1.0
         deltas = np.array([0.5])
         changepoint_ts = np.array([5])
 
         y = model.piecewise_linear(t, deltas, k, m, changepoint_ts)
-        y_true = np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0,
-                           6.5, 8.0, 9.5, 11.0, 12.5])
-        self.assertEqual((y - y_true).sum(), 0.0)
+        y_true = np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.5, 8.0, 9.5, 11.0, 12.5])
+        assert (y - y_true).sum() == 0.0
 
         t = t[8:]
         y_true = y_true[8:]
         y = model.piecewise_linear(t, deltas, k, m, changepoint_ts)
-        self.assertEqual((y - y_true).sum(), 0.0)
+        assert (y - y_true).sum() == 0.0
 
-    def test_piecewise_logistic(self):
-        model = Prophet()
+    def test_piecewise_logistic(self, backend):
+        model = Prophet(stan_backend=backend)
 
-        t = np.arange(11.)
+        t = np.arange(11.0)
         cap = np.ones(11) * 10
         m = 0
         k = 1.0
@@ -363,542 +272,626 @@ class TestProphet(TestCase):
         changepoint_ts = np.array([5])
 
         y = model.piecewise_logistic(t, cap, deltas, k, m, changepoint_ts)
-        y_true = np.array([5.000000, 7.310586, 8.807971, 9.525741, 9.820138,
-                           9.933071, 9.984988, 9.996646, 9.999252, 9.999833,
-                           9.999963])
-        self.assertAlmostEqual((y - y_true).sum(), 0.0, places=5)
+        y_true = np.array(
+            [
+                5.000000,
+                7.310586,
+                8.807971,
+                9.525741,
+                9.820138,
+                9.933071,
+                9.984988,
+                9.996646,
+                9.999252,
+                9.999833,
+                9.999963,
+            ]
+        )
 
         t = t[8:]
         y_true = y_true[8:]
         cap = cap[8:]
         y = model.piecewise_logistic(t, cap, deltas, k, m, changepoint_ts)
-        self.assertAlmostEqual((y - y_true).sum(), 0.0, places=5)
+        assert (y - y_true).sum() == pytest.approx(0.0, abs=1e-5)
 
-    def test_flat_trend(self):
-        model = Prophet()
+    def test_flat_trend(self, backend):
+        model = Prophet(stan_backend=backend)
         t = np.arange(11)
         m = 0.5
         y = model.flat_trend(t, m)
-        y_true = np.array([0.5]*11)
-        self.assertEqual((y - y_true).sum(), 0)
+        y_true = np.array([0.5] * 11)
+        assert (y - y_true).sum() == 0.0
         t = t[8:]
         y_true = y_true[8:]
         y = model.flat_trend(t, m)
-        self.assertEqual((y - y_true).sum(), 0)
+        assert (y - y_true).sum() == 0.0
 
-    def test_holidays(self):
-        holidays = pd.DataFrame({
-            'ds': pd.to_datetime(['2016-12-25']),
-            'holiday': ['xmas'],
-            'lower_window': [-1],
-            'upper_window': [0],
-        })
-        model = Prophet(holidays=holidays)
-        df = pd.DataFrame({
-            'ds': pd.date_range('2016-12-20', '2016-12-31')
-        })
-        feats, priors, names = model.make_holiday_features(df['ds'], model.holidays)
-        # 11 columns generated even though only 8 overlap
-        self.assertEqual(feats.shape, (df.shape[0], 2))
-        self.assertEqual((feats.sum(0) - np.array([1.0, 1.0])).sum(), 0)
-        self.assertEqual(priors, [10., 10.])  # Default prior
-        self.assertEqual(names, ['xmas'])
+    def test_get_changepoints(self, daily_univariate_ts, backend):
+        """
+        By default, Prophet uses the first 80% of the history to detect changepoints.
+        """
+        train, _ = train_test_split(daily_univariate_ts, daily_univariate_ts.shape[0] // 2)
+        m = Prophet(stan_backend=backend)
+        history = m.setup_dataframe(train, initialize_scales=True)
+        m.history = history
+        m.set_changepoints()
+        cp = m.changepoints_t
+        assert cp.shape[0] == m.n_changepoints
+        assert len(cp.shape) == 1
+        assert cp.min() > 0
+        cp_indx = int(np.ceil(0.8 * history.shape[0]))
+        assert cp.max() <= history["t"].values[cp_indx]
 
-        holidays = pd.DataFrame({
-            'ds': pd.to_datetime(['2016-12-25']),
-            'holiday': ['xmas'],
-            'lower_window': [-1],
-            'upper_window': [10],
-        })
-        m = Prophet(holidays=holidays)
-        feats, priors, names = m.make_holiday_features(df['ds'], m.holidays)
-        # 12 columns generated even though only 8 overlap
-        self.assertEqual(feats.shape, (df.shape[0], 12))
-        self.assertEqual(priors, list(10. * np.ones(12)))
-        self.assertEqual(names, ['xmas'])
-        # Check prior specifications
-        holidays = pd.DataFrame({
-            'ds': pd.to_datetime(['2016-12-25', '2017-12-25']),
-            'holiday': ['xmas', 'xmas'],
-            'lower_window': [-1, -1],
-            'upper_window': [0, 0],
-            'prior_scale': [5., 5.],
-        })
-        m = Prophet(holidays=holidays)
-        feats, priors, names = m.make_holiday_features(df['ds'], m.holidays)
-        self.assertEqual(priors, [5., 5.])
-        self.assertEqual(names, ['xmas'])
-        # 2 different priors
-        holidays2 = pd.DataFrame({
-            'ds': pd.to_datetime(['2012-06-06', '2013-06-06']),
-            'holiday': ['seans-bday'] * 2,
-            'lower_window': [0] * 2,
-            'upper_window': [1] * 2,
-            'prior_scale': [8] * 2,
-        })
-        holidays2 = pd.concat((holidays, holidays2), sort=True)
-        m = Prophet(holidays=holidays2)
-        feats, priors, names = m.make_holiday_features(df['ds'], m.holidays)
-        pn = zip(priors, [s.split('_delim_')[0] for s in feats.columns])
-        for t in pn:
-            self.assertIn(t, [(8., 'seans-bday'), (5., 'xmas')])
-        holidays2 = pd.DataFrame({
-            'ds': pd.to_datetime(['2012-06-06', '2013-06-06']),
-            'holiday': ['seans-bday'] * 2,
-            'lower_window': [0] * 2,
-            'upper_window': [1] * 2,
-        })
-        holidays2 = pd.concat((holidays, holidays2), sort=True)
-        feats, priors, names = Prophet(
-            holidays=holidays2, holidays_prior_scale=4
-        ).make_holiday_features(df['ds'], holidays2)
-        self.assertEqual(set(priors), {4., 5.})
-        # Check incompatible priors
-        holidays = pd.DataFrame({
-            'ds': pd.to_datetime(['2016-12-25', '2016-12-27']),
-            'holiday': ['xmasish', 'xmasish'],
-            'lower_window': [-1, -1],
-            'upper_window': [0, 0],
-            'prior_scale': [5., 6.],
-        })
-        with self.assertRaises(ValueError):
-            Prophet(holidays=holidays).make_holiday_features(df['ds'], holidays)
+    def test_set_changepoint_range(self, daily_univariate_ts, backend):
+        train, _ = train_test_split(daily_univariate_ts, daily_univariate_ts.shape[0] // 2)
+        m = Prophet(changepoint_range=0.4, stan_backend=backend)
+        history = m.setup_dataframe(train, initialize_scales=True)
+        m.history = history
+        m.set_changepoints()
+        cp = m.changepoints_t
+        assert cp.shape[0] == m.n_changepoints
+        assert len(cp.shape) == 1
+        assert cp.min() > 0
+        cp_indx = int(np.ceil(0.4 * history.shape[0]))
+        cp.max() <= history["t"].values[cp_indx]
+        for out_of_range in [-0.1, 2]:
+            with pytest.raises(ValueError):
+                m = Prophet(changepoint_range=out_of_range, stan_backend=backend)
 
-    def test_fit_with_holidays(self):
-        holidays = pd.DataFrame({
-            'ds': pd.to_datetime(['2012-06-06', '2013-06-06']),
-            'holiday': ['seans-bday'] * 2,
-            'lower_window': [0] * 2,
-            'upper_window': [1] * 2,
-        })
-        model = Prophet(holidays=holidays, uncertainty_samples=0)
-        model.fit(DATA).predict()
+    def test_get_zero_changepoints(self, daily_univariate_ts, backend):
+        train, _ = train_test_split(daily_univariate_ts, daily_univariate_ts.shape[0] // 2)
+        m = Prophet(n_changepoints=0, stan_backend=backend)
+        history = m.setup_dataframe(train, initialize_scales=True)
+        m.history = history
+        m.set_changepoints()
+        cp = m.changepoints_t
+        assert cp.shape[0] == 1
+        assert cp[0] == 0
 
-    def test_fit_predict_with_country_holidays(self):
-        holidays = pd.DataFrame({
-            'ds': pd.to_datetime(['2012-06-06', '2013-06-06']),
-            'holiday': ['seans-bday'] * 2,
-            'lower_window': [0] * 2,
-            'upper_window': [1] * 2,
-        })
-        # Test with holidays and country_holidays
-        model = Prophet(holidays=holidays, uncertainty_samples=0)
-        model.add_country_holidays(country_name='US')
-        model.fit(DATA).predict()
-        # There are training holidays missing in the test set
-        train = DATA.head(154)
-        future = DATA.tail(355)
-        model = Prophet(uncertainty_samples=0)
-        model.add_country_holidays(country_name='US')
-        model.fit(train).predict(future)
-        # There are test holidays missing in the training set
-        train = DATA.tail(355)
-        future = DATA2
-        model = Prophet(uncertainty_samples=0)
-        model.add_country_holidays(country_name='US')
-        model.fit(train).predict(future)
+    def test_override_n_changepoints(self, daily_univariate_ts, backend):
+        train = daily_univariate_ts.head(20).copy()
+        m = Prophet(n_changepoints=15, stan_backend=backend)
+        history = m.setup_dataframe(train, initialize_scales=True)
+        m.history = history
+        m.set_changepoints()
+        assert m.n_changepoints == 15
+        cp = m.changepoints_t
+        assert cp.shape[0] == 15
 
-    def test_make_future_dataframe(self):
-        N = 468
-        train = DATA.head(N // 2)
-        forecaster = Prophet()
-        forecaster.fit(train)
-        future = forecaster.make_future_dataframe(periods=3, freq='D',
-                                                  include_history=False)
-        correct = pd.DatetimeIndex(['2013-04-26', '2013-04-27', '2013-04-28'])
-        self.assertEqual(len(future), 3)
-        for i in range(3):
-            self.assertEqual(future.iloc[i]['ds'], correct[i])
 
-        future = forecaster.make_future_dataframe(periods=3, freq='M',
-                                                  include_history=False)
-        correct = pd.DatetimeIndex(['2013-04-30', '2013-05-31', '2013-06-30'])
-        self.assertEqual(len(future), 3)
-        for i in range(3):
-            self.assertEqual(future.iloc[i]['ds'], correct[i])
+class TestProphetSeasonalComponent:
+    def test_fourier_series_weekly(self, daily_univariate_ts):
+        mat = Prophet.fourier_series(daily_univariate_ts["ds"], 7, 3)
+        # These are from the R forecast package directly.
+        true_values = np.array([0.7818315, 0.6234898, 0.9749279, -0.2225209, 0.4338837, -0.9009689])
+        assert np.sum((mat[0] - true_values) ** 2) == pytest.approx(0.0)
 
-    def test_auto_weekly_seasonality(self):
-        # Should be enabled
-        N = 15
-        train = DATA.head(N)
-        m = Prophet()
-        self.assertEqual(m.weekly_seasonality, 'auto')
-        m.fit(train)
-        self.assertIn('weekly', m.seasonalities)
-        self.assertEqual(
-            m.seasonalities['weekly'],
-            {
-                'period': 7,
-                'fourier_order': 3,
-                'prior_scale': 10.,
-                'mode': 'additive',
-                'condition_name': None
-            },
+    def test_fourier_series_yearly(self, daily_univariate_ts):
+        mat = Prophet.fourier_series(daily_univariate_ts["ds"], 365.25, 3)
+        # These are from the R forecast package directly.
+        true_values = np.array(
+            [0.7006152, -0.7135393, -0.9998330, 0.01827656, 0.7262249, 0.6874572]
         )
+        assert np.sum((mat[0] - true_values) ** 2) == pytest.approx(0.0)
+
+    def test_auto_weekly_seasonality(self, daily_univariate_ts, backend):
+        # Should be enabled
+        train = daily_univariate_ts.head(15)
+        m = Prophet(stan_backend=backend)
+        assert m.weekly_seasonality == "auto"
+        m.fit(train)
+        assert "weekly" in m.seasonalities
+        assert m.seasonalities["weekly"] == {
+            "period": 7,
+            "fourier_order": 3,
+            "prior_scale": 10.0,
+            "mode": "additive",
+            "condition_name": None,
+        }
         # Should be disabled due to too short history
-        N = 9
-        train = DATA.head(N)
-        m = Prophet()
+        train = daily_univariate_ts.head(9)
+        m = Prophet(stan_backend=backend)
         m.fit(train)
-        self.assertNotIn('weekly', m.seasonalities)
-        m = Prophet(weekly_seasonality=True)
+        assert "weekly" not in m.seasonalities
+        m = Prophet(weekly_seasonality=True, stan_backend=backend)
         m.fit(train)
-        self.assertIn('weekly', m.seasonalities)
+        assert "weekly" in m.seasonalities
         # Should be False due to weekly spacing
-        train = DATA.iloc[::7, :]
-        m = Prophet()
+        train = daily_univariate_ts.iloc[::7, :]
+        m = Prophet(stan_backend=backend)
         m.fit(train)
-        self.assertNotIn('weekly', m.seasonalities)
-        m = Prophet(weekly_seasonality=2, seasonality_prior_scale=3.)
-        m.fit(DATA)
-        self.assertEqual(
-            m.seasonalities['weekly'],
-            {
-                'period': 7,
-                'fourier_order': 2,
-                'prior_scale': 3.,
-                'mode': 'additive',
-                'condition_name': None
-            },
-        )
+        assert "weekly" not in m.seasonalities
+        m = Prophet(weekly_seasonality=2, seasonality_prior_scale=3.0, stan_backend=backend)
+        m.fit(daily_univariate_ts)
+        assert m.seasonalities["weekly"] == {
+            "period": 7,
+            "fourier_order": 2,
+            "prior_scale": 3.0,
+            "mode": "additive",
+            "condition_name": None,
+        }
 
-    def test_auto_yearly_seasonality(self):
+    def test_auto_yearly_seasonality(self, daily_univariate_ts, backend):
         # Should be enabled
-        m = Prophet()
-        self.assertEqual(m.yearly_seasonality, 'auto')
-        m.fit(DATA)
-        self.assertIn('yearly', m.seasonalities)
-        self.assertEqual(
-            m.seasonalities['yearly'],
-            {
-                'period': 365.25,
-                'fourier_order': 10,
-                'prior_scale': 10.,
-                'mode': 'additive',
-                'condition_name': None
-            },
-        )
+        m = Prophet(stan_backend=backend)
+        assert m.yearly_seasonality == "auto"
+        m.fit(daily_univariate_ts)
+        assert "yearly" in m.seasonalities
+        assert m.seasonalities["yearly"] == {
+            "period": 365.25,
+            "fourier_order": 10,
+            "prior_scale": 10.0,
+            "mode": "additive",
+            "condition_name": None,
+        }
         # Should be disabled due to too short history
-        N = 240
-        train = DATA.head(N)
-        m = Prophet()
+        train = daily_univariate_ts.head(240)
+        m = Prophet(stan_backend=backend)
         m.fit(train)
-        self.assertNotIn('yearly', m.seasonalities)
-        m = Prophet(yearly_seasonality=True)
+        assert "yearly" not in m.seasonalities
+        m = Prophet(yearly_seasonality=True, stan_backend=backend)
         m.fit(train)
-        self.assertIn('yearly', m.seasonalities)
-        m = Prophet(yearly_seasonality=7, seasonality_prior_scale=3.)
-        m.fit(DATA)
-        self.assertEqual(
-            m.seasonalities['yearly'],
-            {
-                'period': 365.25,
-                'fourier_order': 7,
-                'prior_scale': 3.,
-                'mode': 'additive',
-                'condition_name': None
-            },
-        )
+        assert "yearly" in m.seasonalities
+        m = Prophet(yearly_seasonality=7, seasonality_prior_scale=3.0, stan_backend=backend)
+        m.fit(daily_univariate_ts)
+        assert m.seasonalities["yearly"] == {
+            "period": 365.25,
+            "fourier_order": 7,
+            "prior_scale": 3.0,
+            "mode": "additive",
+            "condition_name": None,
+        }
 
-    def test_auto_daily_seasonality(self):
+    def test_auto_daily_seasonality(self, daily_univariate_ts, subdaily_univariate_ts, backend):
         # Should be enabled
-        m = Prophet()
-        self.assertEqual(m.daily_seasonality, 'auto')
-        m.fit(DATA2)
-        self.assertIn('daily', m.seasonalities)
-        self.assertEqual(
-            m.seasonalities['daily'],
-            {
-                'period': 1,
-                'fourier_order': 4,
-                'prior_scale': 10.,
-                'mode': 'additive',
-                'condition_name': None
-            },
-        )
+        m = Prophet(stan_backend=backend)
+        assert m.daily_seasonality == "auto"
+        m.fit(subdaily_univariate_ts)
+        assert "daily" in m.seasonalities
+        assert m.seasonalities["daily"] == {
+            "period": 1,
+            "fourier_order": 4,
+            "prior_scale": 10.0,
+            "mode": "additive",
+            "condition_name": None,
+        }
         # Should be disabled due to too short history
-        N = 430
-        train = DATA2.head(N)
-        m = Prophet()
+        train = subdaily_univariate_ts.head(430)
+        m = Prophet(stan_backend=backend)
         m.fit(train)
-        self.assertNotIn('daily', m.seasonalities)
-        m = Prophet(daily_seasonality=True)
+        assert "daily" not in m.seasonalities
+        m = Prophet(daily_seasonality=True, stan_backend=backend)
         m.fit(train)
-        self.assertIn('daily', m.seasonalities)
-        m = Prophet(daily_seasonality=7, seasonality_prior_scale=3.)
-        m.fit(DATA2)
-        self.assertEqual(
-            m.seasonalities['daily'],
-            {
-                'period': 1,
-                'fourier_order': 7,
-                'prior_scale': 3.,
-                'mode': 'additive',
-                'condition_name': None
-            },
-        )
-        m = Prophet()
-        m.fit(DATA)
-        self.assertNotIn('daily', m.seasonalities)
+        assert "daily" in m.seasonalities
+        m = Prophet(daily_seasonality=7, seasonality_prior_scale=3.0, stan_backend=backend)
+        m.fit(subdaily_univariate_ts)
+        assert m.seasonalities["daily"] == {
+            "period": 1,
+            "fourier_order": 7,
+            "prior_scale": 3.0,
+            "mode": "additive",
+            "condition_name": None,
+        }
+        m = Prophet(stan_backend=backend)
+        m.fit(daily_univariate_ts)
+        assert "daily" not in m.seasonalities
 
-    def test_subdaily_holidays(self):
-        holidays = pd.DataFrame({
-            'ds': pd.to_datetime(['2017-01-02']),
-            'holiday': ['special_day'],
-        })
-        m = Prophet(holidays=holidays)
-        m.fit(DATA2)
-        fcst = m.predict()
-        self.assertEqual(sum(fcst['special_day'] == 0), 575)
-
-    def test_custom_seasonality(self):
-        holidays = pd.DataFrame({
-            'ds': pd.to_datetime(['2017-01-02']),
-            'holiday': ['special_day'],
-            'prior_scale': [4.],
-        })
-        m = Prophet(holidays=holidays)
-        m.add_seasonality(name='monthly', period=30, fourier_order=5,
-                          prior_scale=2.)
-        self.assertEqual(
-            m.seasonalities['monthly'],
-            {
-                'period': 30,
-                'fourier_order': 5,
-                'prior_scale': 2.,
-                'mode': 'additive',
-                'condition_name': None
-            },
-        )
-        with self.assertRaises(ValueError):
-            m.add_seasonality(name='special_day', period=30, fourier_order=5)
-        with self.assertRaises(ValueError):
-            m.add_seasonality(name='trend', period=30, fourier_order=5)
-        m.add_seasonality(name='weekly', period=30, fourier_order=5)
-        # Test fourier order <= 0
-        m = Prophet()
-        with self.assertRaises(ValueError):
-            m.add_seasonality(name='weekly', period=7, fourier_order=0)
-        with self.assertRaises(ValueError):
-            m.add_seasonality(name='weekly', period=7, fourier_order=-1)
-        # Test priors
-        m = Prophet(
-            holidays=holidays, yearly_seasonality=False,
-            seasonality_mode='multiplicative'
-        )
-        m.add_seasonality(name='monthly', period=30, fourier_order=5,
-                          prior_scale=2., mode='additive')
-        m.fit(DATA.copy())
-        self.assertEqual(m.seasonalities['monthly']['mode'], 'additive')
-        self.assertEqual(m.seasonalities['weekly']['mode'], 'multiplicative')
-        seasonal_features, prior_scales, component_cols, modes = (
-            m.make_all_seasonality_features(m.history)
-        )
-        self.assertEqual(sum(component_cols['monthly']), 10)
-        self.assertEqual(sum(component_cols['special_day']), 1)
-        self.assertEqual(sum(component_cols['weekly']), 6)
-        self.assertEqual(sum(component_cols['additive_terms']), 10)
-        self.assertEqual(sum(component_cols['multiplicative_terms']), 7)
-        if seasonal_features.columns[0] == 'monthly_delim_1':
-            true = [2.] * 10 + [10.] * 6 + [4.]
-            self.assertEqual(sum(component_cols['monthly'][:10]), 10)
-            self.assertEqual(sum(component_cols['weekly'][10:16]), 6)
-        else:
-            true = [10.] * 6 + [2.] * 10 + [4.]
-            self.assertEqual(sum(component_cols['weekly'][:6]), 6)
-            self.assertEqual(sum(component_cols['monthly'][6:16]), 10)
-        self.assertEqual(prior_scales, true)
-
-    def test_conditional_custom_seasonality(self):
-        m = Prophet(weekly_seasonality=False, yearly_seasonality=False)
-        m.add_seasonality(name='conditional_weekly', period=7, fourier_order=3,
-                          prior_scale=2., condition_name='is_conditional_week')
-        m.add_seasonality(name='normal_monthly', period=30.5, fourier_order=5,
-                          prior_scale=2.)
-        df = DATA.copy()
-        with self.assertRaises(ValueError):
-            # Require all conditions names in df
-            m.fit(df)
-        df['is_conditional_week'] = [0] * 255 + [2] * 255
-        with self.assertRaises(ValueError):
-            # Require boolean compatible values
-            m.fit(df)
-        df['is_conditional_week'] = [0] * 255 + [1] * 255
-        m.fit(df)
-        self.assertEqual(
-            m.seasonalities['conditional_weekly'],
-            {
-                'period': 7,
-                'fourier_order': 3,
-                'prior_scale': 2.,
-                'mode': 'additive',
-                'condition_name': 'is_conditional_week'
-            },
-        )
-        self.assertIsNone(m.seasonalities['normal_monthly']['condition_name'])
-        seasonal_features, prior_scales, component_cols, modes = (
-            m.make_all_seasonality_features(m.history)
-        )
-        # Confirm that only values without is_conditional_week has non zero entries
-        conditional_weekly_columns = seasonal_features.columns[
-            seasonal_features.columns.str.startswith('conditional_weekly')]
-        self.assertTrue(np.array_equal((seasonal_features[conditional_weekly_columns] != 0).any(axis=1).values,
-                                       df['is_conditional_week'].values))
-
-    def test_added_regressors(self):
-        m = Prophet()
-        m.add_regressor('binary_feature', prior_scale=0.2)
-        m.add_regressor('numeric_feature', prior_scale=0.5)
-        m.add_regressor(
-            'numeric_feature2', prior_scale=0.5, mode='multiplicative'
-        )
-        m.add_regressor('binary_feature2', standardize=True)
-        df = DATA.copy()
-        df['binary_feature'] = ['0'] * 255 + ['1'] * 255
-        df['numeric_feature'] = range(510)
-        df['numeric_feature2'] = range(510)
-        with self.assertRaises(ValueError):
-            # Require all regressors in df
-            m.fit(df)
-        df['binary_feature2'] = [1] * 100 + [0] * 410
-        m.fit(df)
-        # Check that standardizations are correctly set
-        self.assertEqual(
-            m.extra_regressors['binary_feature'],
-            {
-                'prior_scale': 0.2,
-                'mu': 0,
-                'std': 1,
-                'standardize': 'auto',
-                'mode': 'additive',
-            },
-        )
-        self.assertEqual(
-            m.extra_regressors['numeric_feature']['prior_scale'], 0.5)
-        self.assertEqual(
-            m.extra_regressors['numeric_feature']['mu'], 254.5)
-        self.assertAlmostEqual(
-            m.extra_regressors['numeric_feature']['std'], 147.368585, places=5)
-        self.assertEqual(
-            m.extra_regressors['numeric_feature2']['mode'], 'multiplicative')
-        self.assertEqual(
-            m.extra_regressors['binary_feature2']['prior_scale'], 10.)
-        self.assertAlmostEqual(
-            m.extra_regressors['binary_feature2']['mu'], 0.1960784, places=5)
-        self.assertAlmostEqual(
-            m.extra_regressors['binary_feature2']['std'], 0.3974183, places=5)
-        # Check that standardization is done correctly
-        df2 = m.setup_dataframe(df.copy())
-        self.assertEqual(df2['binary_feature'][0], 0)
-        self.assertAlmostEqual(df2['numeric_feature'][0], -1.726962, places=4)
-        self.assertAlmostEqual(df2['binary_feature2'][0], 2.022859, places=4)
-        # Check that feature matrix and prior scales are correctly constructed
-        seasonal_features, prior_scales, component_cols, modes = (
-            m.make_all_seasonality_features(df2)
-        )
-        self.assertEqual(seasonal_features.shape[1], 30)
-        names = ['binary_feature', 'numeric_feature', 'binary_feature2']
-        true_priors = [0.2, 0.5, 10.]
-        for i, name in enumerate(names):
-            self.assertIn(name, seasonal_features)
-            self.assertEqual(sum(component_cols[name]), 1)
-            self.assertEqual(
-                sum(np.array(prior_scales) * component_cols[name]),
-                true_priors[i],
-            )
-        # Check that forecast components are reasonable
-        future = pd.DataFrame({
-            'ds': ['2014-06-01'],
-            'binary_feature': [0],
-            'numeric_feature': [10],
-            'numeric_feature2': [10],
-        })
-        with self.assertRaises(ValueError):
-            m.predict(future)
-        future['binary_feature2'] = 0
-        fcst = m.predict(future)
-        self.assertEqual(fcst.shape[1], 37)
-        self.assertEqual(fcst['binary_feature'][0], 0)
-        self.assertAlmostEqual(
-            fcst['extra_regressors_additive'][0],
-            fcst['numeric_feature'][0] + fcst['binary_feature2'][0],
-        )
-        self.assertAlmostEqual(
-            fcst['extra_regressors_multiplicative'][0],
-            fcst['numeric_feature2'][0],
-        )
-        self.assertAlmostEqual(
-            fcst['additive_terms'][0],
-            fcst['yearly'][0] + fcst['weekly'][0]
-            + fcst['extra_regressors_additive'][0],
-        )
-        self.assertAlmostEqual(
-            fcst['multiplicative_terms'][0],
-            fcst['extra_regressors_multiplicative'][0],
-        )
-        self.assertAlmostEqual(
-            fcst['yhat'][0],
-            fcst['trend'][0] * (1 + fcst['multiplicative_terms'][0])
-            + fcst['additive_terms'][0],
-        )
-        # Check works if constant extra regressor at 0
-        df['constant_feature'] = 0
-        m = Prophet()
-        m.add_regressor('constant_feature')
-        m.fit(df)
-        self.assertEqual(m.extra_regressors['constant_feature']['std'], 1)
-
-    def test_set_seasonality_mode(self):
+    def test_set_seasonality_mode(self, backend):
         # Setting attribute
-        m = Prophet()
-        self.assertEqual(m.seasonality_mode, 'additive')
-        m = Prophet(seasonality_mode='multiplicative')
-        self.assertEqual(m.seasonality_mode, 'multiplicative')
-        with self.assertRaises(ValueError):
-            Prophet(seasonality_mode='batman')
+        m = Prophet(stan_backend=backend)
+        assert m.seasonality_mode == "additive"
+        m = Prophet(seasonality_mode="multiplicative", stan_backend=backend)
+        assert m.seasonality_mode == "multiplicative"
+        with pytest.raises(ValueError):
+            Prophet(seasonality_mode="batman", stan_backend=backend)
 
-    def test_seasonality_modes(self):
+    def test_seasonality_modes(self, daily_univariate_ts, backend):
         # Model with holidays, seasonalities, and extra regressors
-        holidays = pd.DataFrame({
-            'ds': pd.to_datetime(['2016-12-25']),
-            'holiday': ['xmas'],
-            'lower_window': [-1],
-            'upper_window': [0],
-        })
-        m = Prophet(seasonality_mode='multiplicative', holidays=holidays)
-        m.add_seasonality('monthly', period=30, mode='additive', fourier_order=3)
-        m.add_regressor('binary_feature', mode='additive')
-        m.add_regressor('numeric_feature')
+        holidays = pd.DataFrame(
+            {
+                "ds": pd.to_datetime(["2016-12-25"]),
+                "holiday": ["xmas"],
+                "lower_window": [-1],
+                "upper_window": [0],
+            }
+        )
+        m = Prophet(seasonality_mode="multiplicative", holidays=holidays, stan_backend=backend)
+        m.add_seasonality("monthly", period=30, mode="additive", fourier_order=3)
+        m.add_regressor("binary_feature", mode="additive")
+        m.add_regressor("numeric_feature")
         # Construct seasonal features
-        df = DATA.copy()
-        df['binary_feature'] = [0] * 255 + [1] * 255
-        df['numeric_feature'] = range(510)
+        df = daily_univariate_ts.copy()
+        df["binary_feature"] = [0] * 255 + [1] * 255
+        df["numeric_feature"] = range(510)
         df = m.setup_dataframe(df, initialize_scales=True)
         m.history = df.copy()
         m.set_auto_seasonalities()
-        seasonal_features, prior_scales, component_cols, modes = (
-            m.make_all_seasonality_features(df))
-        self.assertEqual(sum(component_cols['additive_terms']), 7)
-        self.assertEqual(sum(component_cols['multiplicative_terms']), 29)
-        self.assertEqual(
-            set(modes['additive']),
-            {'monthly', 'binary_feature', 'additive_terms',
-             'extra_regressors_additive'},
+        seasonal_features, prior_scales, component_cols, modes = m.make_all_seasonality_features(df)
+        assert sum(component_cols["additive_terms"]) == 7
+        assert sum(component_cols["multiplicative_terms"]) == 29
+        assert set(modes["additive"]) == {
+            "monthly",
+            "binary_feature",
+            "additive_terms",
+            "extra_regressors_additive",
+        }
+        assert set(modes["multiplicative"]) == {
+            "weekly",
+            "yearly",
+            "xmas",
+            "numeric_feature",
+            "multiplicative_terms",
+            "extra_regressors_multiplicative",
+            "holidays",
+        }
+
+
+class TestProphetCustomSeasonalComponent:
+    def test_custom_monthly_seasonality(self, backend):
+        m = Prophet(stan_backend=backend)
+        m.add_seasonality(name="monthly", period=30, fourier_order=5, prior_scale=2.0)
+        assert m.seasonalities["monthly"] == {
+            "period": 30,
+            "fourier_order": 5,
+            "prior_scale": 2.0,
+            "mode": "additive",
+            "condition_name": None,
+        }
+
+    def test_duplicate_component_names(self, backend):
+        holidays = pd.DataFrame(
+            {
+                "ds": pd.to_datetime(["2017-01-02"]),
+                "holiday": ["special_day"],
+                "prior_scale": [4.0],
+            }
         )
-        self.assertEqual(
-            set(modes['multiplicative']),
-            {'weekly', 'yearly', 'xmas', 'numeric_feature',
-             'multiplicative_terms', 'extra_regressors_multiplicative',
-             'holidays',
-             },
+        m = Prophet(holidays=holidays, stan_backend=backend)
+
+        with pytest.raises(ValueError):
+            m.add_seasonality(name="special_day", period=30, fourier_order=5)
+        with pytest.raises(ValueError):
+            m.add_seasonality(name="trend", period=30, fourier_order=5)
+        m.add_seasonality(name="weekly", period=30, fourier_order=5)
+
+    def test_custom_fourier_order(self, backend):
+        """Fourier order cannot be <= 0"""
+        m = Prophet(stan_backend=backend)
+        with pytest.raises(ValueError):
+            m.add_seasonality(name="weekly", period=7, fourier_order=0)
+        with pytest.raises(ValueError):
+            m.add_seasonality(name="weekly", period=7, fourier_order=-1)
+
+    def test_custom_priors(self, daily_univariate_ts, backend):
+        holidays = pd.DataFrame(
+            {
+                "ds": pd.to_datetime(["2017-01-02"]),
+                "holiday": ["special_day"],
+                "prior_scale": [4.0],
+            }
+        )
+        m = Prophet(
+            holidays=holidays,
+            yearly_seasonality=False,
+            seasonality_mode="multiplicative",
+            stan_backend=backend,
+        )
+        m.add_seasonality(
+            name="monthly", period=30, fourier_order=5, prior_scale=2.0, mode="additive"
+        )
+        m.fit(daily_univariate_ts)
+        assert m.seasonalities["monthly"]["mode"] == "additive"
+        assert m.seasonalities["weekly"]["mode"] == "multiplicative"
+        seasonal_features, prior_scales, component_cols, modes = m.make_all_seasonality_features(
+            m.history
+        )
+        assert sum(component_cols["monthly"]) == 10
+        assert sum(component_cols["special_day"]) == 1
+        assert sum(component_cols["weekly"]) == 6
+        assert sum(component_cols["additive_terms"]) == 10
+        assert sum(component_cols["multiplicative_terms"]) == 7
+
+        if seasonal_features.columns[0] == "monthly_delim_1":
+            true = [2.0] * 10 + [10.0] * 6 + [4.0]
+            assert sum(component_cols["monthly"][:10]) == 10
+            assert sum(component_cols["weekly"][10:16]) == 6
+        else:
+            true = [10.0] * 6 + [2.0] * 10 + [4.0]
+            assert sum(component_cols["weekly"][:6]) == 6
+            assert sum(component_cols["monthly"][6:16]) == 10
+        assert prior_scales == true
+
+    def test_conditional_custom_seasonality(self, daily_univariate_ts, backend):
+        m = Prophet(weekly_seasonality=False, yearly_seasonality=False, stan_backend=backend)
+        m.add_seasonality(
+            name="conditional_weekly",
+            period=7,
+            fourier_order=3,
+            prior_scale=2.0,
+            condition_name="is_conditional_week",
+        )
+        m.add_seasonality(name="normal_monthly", period=30.5, fourier_order=5, prior_scale=2.0)
+        df = daily_univariate_ts.copy()
+        with pytest.raises(ValueError):
+            # Require all conditions names in df
+            m.fit(df)
+        df["is_conditional_week"] = [0] * 255 + [2] * 255
+        with pytest.raises(ValueError):
+            # Require boolean compatible values
+            m.fit(df)
+        df["is_conditional_week"] = [0] * 255 + [1] * 255
+        m.fit(df)
+        assert m.seasonalities["conditional_weekly"] == {
+            "period": 7,
+            "fourier_order": 3,
+            "prior_scale": 2.0,
+            "mode": "additive",
+            "condition_name": "is_conditional_week",
+        }
+        assert m.seasonalities["normal_monthly"]["condition_name"] is None
+        seasonal_features, prior_scales, component_cols, modes = m.make_all_seasonality_features(
+            m.history
+        )
+        # Confirm that only values without is_conditional_week has non zero entries
+        condition_cols = [
+            c for c in seasonal_features.columns if c.startswith("conditional_weekly")
+        ]
+        assert np.array_equal(
+            (seasonal_features[condition_cols] != 0).any(axis=1).values,
+            df["is_conditional_week"].values,
         )
 
-    def test_fit_warm_start(self):
-        m = Prophet().fit(DATA.iloc[:500])
-        m2 = Prophet().fit(DATA.iloc[:510], init=warm_start_params(m))
-        self.assertEqual(len(m2.params['delta'][0]), 25)
 
-    def test_sampling_warm_start(self):
-        m = Prophet(mcmc_samples=100).fit(DATA.iloc[:500], show_progress=False)
-        m2 = Prophet(mcmc_samples=100).fit(DATA.iloc[:510], init=warm_start_params(m), show_progress=False)
-        self.assertEqual(m2.params['delta'].shape, (200, 25))
+class TestProphetHolidays:
+    def test_holidays_lower_window(self, backend):
+        holidays = pd.DataFrame(
+            {
+                "ds": pd.to_datetime(["2016-12-25"]),
+                "holiday": ["xmas"],
+                "lower_window": [-1],
+                "upper_window": [0],
+            }
+        )
+        model = Prophet(holidays=holidays, stan_backend=backend)
+        df = pd.DataFrame({"ds": pd.date_range("2016-12-20", "2016-12-31")})
+        feats, priors, names = model.make_holiday_features(df["ds"], model.holidays)
+        assert feats.shape == (df.shape[0], 2)
+        assert (feats.sum(axis=0) - np.array([1.0, 1.0])).sum() == 0.0
+        assert priors == [10.0, 10.0]  # Default prior
+        assert names == ["xmas"]
+
+    def test_holidays_upper_window(self, backend):
+        holidays = pd.DataFrame(
+            {
+                "ds": pd.to_datetime(["2016-12-25"]),
+                "holiday": ["xmas"],
+                "lower_window": [-1],
+                "upper_window": [10],
+            }
+        )
+        m = Prophet(holidays=holidays, stan_backend=backend)
+        df = pd.DataFrame({"ds": pd.date_range("2016-12-20", "2016-12-31")})
+        feats, priors, names = m.make_holiday_features(df["ds"], m.holidays)
+        # 12 columns generated even though only 8 overlap
+        assert feats.shape == (df.shape[0], 12)
+        assert priors == [10.0 for _ in range(12)]
+        assert names == ["xmas"]
+
+    def test_holidays_priors(self, backend):
+        # Check prior specifications
+        holidays = pd.DataFrame(
+            {
+                "ds": pd.to_datetime(["2016-12-25", "2017-12-25"]),
+                "holiday": ["xmas", "xmas"],
+                "lower_window": [-1, -1],
+                "upper_window": [0, 0],
+                "prior_scale": [5.0, 5.0],
+            }
+        )
+        m = Prophet(holidays=holidays, stan_backend=backend)
+        df = pd.DataFrame({"ds": pd.date_range("2016-12-20", "2016-12-31")})
+        feats, priors, names = m.make_holiday_features(df["ds"], m.holidays)
+        assert priors == [5.0, 5.0]
+        assert names == ["xmas"]
+        # 2 different priors
+        holidays2 = pd.DataFrame(
+            {
+                "ds": pd.to_datetime(["2012-06-06", "2013-06-06"]),
+                "holiday": ["seans-bday"] * 2,
+                "lower_window": [0] * 2,
+                "upper_window": [1] * 2,
+                "prior_scale": [8] * 2,
+            }
+        )
+        holidays2 = pd.concat((holidays, holidays2), sort=True)
+        m = Prophet(holidays=holidays2, stan_backend=backend)
+        feats, priors, names = m.make_holiday_features(df["ds"], m.holidays)
+        pn = zip(priors, [s.split("_delim_")[0] for s in feats.columns])
+        for t in pn:
+            assert t in [(8.0, "seans-bday"), (5.0, "xmas")]
+        holidays2 = pd.DataFrame(
+            {
+                "ds": pd.to_datetime(["2012-06-06", "2013-06-06"]),
+                "holiday": ["seans-bday"] * 2,
+                "lower_window": [0] * 2,
+                "upper_window": [1] * 2,
+            }
+        )
+        holidays2 = pd.concat((holidays, holidays2), sort=True)
+        feats, priors, names = Prophet(
+            holidays=holidays2, holidays_prior_scale=4, stan_backend=backend
+        ).make_holiday_features(df["ds"], holidays2)
+        assert set(priors) == {4.0, 5.0}
+
+    def test_holidays_bad_priors(self, backend):
+        holidays = pd.DataFrame(
+            {
+                "ds": pd.to_datetime(["2016-12-25", "2016-12-27"]),
+                "holiday": ["xmasish", "xmasish"],
+                "lower_window": [-1, -1],
+                "upper_window": [0, 0],
+                "prior_scale": [5.0, 6.0],
+            }
+        )
+        df = pd.DataFrame({"ds": pd.date_range("2016-12-20", "2016-12-31")})
+        with pytest.raises(ValueError):
+            Prophet(holidays=holidays, stan_backend=backend).make_holiday_features(
+                df["ds"], holidays
+            )
+
+    def test_fit_with_holidays(self, daily_univariate_ts, backend):
+        holidays = pd.DataFrame(
+            {
+                "ds": pd.to_datetime(["2012-06-06", "2013-06-06"]),
+                "holiday": ["seans-bday"] * 2,
+                "lower_window": [0] * 2,
+                "upper_window": [1] * 2,
+            }
+        )
+        model = Prophet(holidays=holidays, uncertainty_samples=0, stan_backend=backend)
+        model.fit(daily_univariate_ts).predict()
+
+    def test_fit_predict_with_country_holidays(self, daily_univariate_ts, backend):
+        holidays = pd.DataFrame(
+            {
+                "ds": pd.to_datetime(["2012-06-06", "2013-06-06"]),
+                "holiday": ["seans-bday"] * 2,
+                "lower_window": [0] * 2,
+                "upper_window": [1] * 2,
+            }
+        )
+        # Test with holidays and country_holidays
+        model = Prophet(holidays=holidays, uncertainty_samples=0, stan_backend=backend)
+        model.add_country_holidays(country_name="US")
+        model.fit(daily_univariate_ts).predict()
+        # There are training holidays missing in the test set
+        train = daily_univariate_ts.head(154)
+        future = daily_univariate_ts.tail(355)
+        model = Prophet(uncertainty_samples=0, stan_backend=backend)
+        model.add_country_holidays(country_name="US")
+        model.fit(train).predict(future)
+        # There are test holidays missing in the training set
+        train = daily_univariate_ts.tail(355)
+        model = Prophet(uncertainty_samples=0, stan_backend=backend)
+        model.add_country_holidays(country_name="US")
+        model.fit(train)
+        future = model.make_future_dataframe(periods=60, include_history=False)
+        model.predict(future)
+
+    def test_subdaily_holidays(self, subdaily_univariate_ts, backend):
+        holidays = pd.DataFrame(
+            {
+                "ds": pd.to_datetime(["2017-01-02"]),
+                "holiday": ["special_day"],
+            }
+        )
+        m = Prophet(holidays=holidays, stan_backend=backend)
+        m.fit(subdaily_univariate_ts)
+        fcst = m.predict()
+        assert sum(fcst["special_day"] == 0) == 575
+
+
+class TestProphetRegressors:
+    def test_added_regressors(self, daily_univariate_ts, backend):
+        m = Prophet(stan_backend=backend)
+        m.add_regressor("binary_feature", prior_scale=0.2)
+        m.add_regressor("numeric_feature", prior_scale=0.5)
+        m.add_regressor("numeric_feature2", prior_scale=0.5, mode="multiplicative")
+        m.add_regressor("binary_feature2", standardize=True)
+        df = daily_univariate_ts.copy()
+        df["binary_feature"] = ["0"] * 255 + ["1"] * 255
+        df["numeric_feature"] = range(510)
+        df["numeric_feature2"] = range(510)
+        with pytest.raises(ValueError):
+            # Require all regressors in df
+            m.fit(df)
+        df["binary_feature2"] = [1] * 100 + [0] * 410
+        m.fit(df)
+        # Check that standardizations are correctly set
+        assert m.extra_regressors["binary_feature"] == {
+            "prior_scale": 0.2,
+            "mu": 0,
+            "std": 1,
+            "standardize": "auto",
+            "mode": "additive",
+        }
+        assert m.extra_regressors["numeric_feature"]["prior_scale"] == 0.5
+        assert m.extra_regressors["numeric_feature"]["mu"] == 254.5
+        assert m.extra_regressors["numeric_feature"]["std"] == pytest.approx(147.368585, abs=1e-5)
+        assert m.extra_regressors["numeric_feature2"]["mode"] == "multiplicative"
+        assert m.extra_regressors["binary_feature2"]["prior_scale"] == 10.0
+        assert m.extra_regressors["binary_feature2"]["mu"] == pytest.approx(0.1960784, abs=1e-5)
+        assert m.extra_regressors["binary_feature2"]["std"] == pytest.approx(0.3974183, abs=1e-5)
+        # Check that standardization is done correctly
+        df2 = m.setup_dataframe(df.copy())
+        assert df2["binary_feature"][0] == 0
+        assert df2["numeric_feature"][0] == pytest.approx(-1.726962, abs=1e-4)
+        assert df2["binary_feature2"][0] == pytest.approx(2.022859, abs=1e-4)
+        # Check that feature matrix and prior scales are correctly constructed
+        seasonal_features, prior_scales, component_cols, modes = m.make_all_seasonality_features(
+            df2
+        )
+        assert seasonal_features.shape[1] == 30
+        names = ["binary_feature", "numeric_feature", "binary_feature2"]
+        true_priors = [0.2, 0.5, 10.0]
+        for i, name in enumerate(names):
+            assert name in seasonal_features
+            assert sum(component_cols[name]) == 1
+            assert sum(np.array(prior_scales) * component_cols[name]) == true_priors[i]
+        # Check that forecast components are reasonable
+        future = pd.DataFrame(
+            {
+                "ds": ["2014-06-01"],
+                "binary_feature": [0],
+                "numeric_feature": [10],
+                "numeric_feature2": [10],
+            }
+        )
+        # future dataframe also requires regressor values
+        with pytest.raises(ValueError):
+            m.predict(future)
+        future["binary_feature2"] = 0
+        fcst = m.predict(future)
+        assert fcst.shape[1] == 37
+        assert fcst["binary_feature"][0] == 0
+        assert fcst["extra_regressors_additive"][0] == pytest.approx(
+            fcst["numeric_feature"][0] + fcst["binary_feature2"][0]
+        )
+        assert fcst["extra_regressors_multiplicative"][0] == pytest.approx(
+            fcst["numeric_feature2"][0]
+        )
+        assert fcst["additive_terms"][0] == pytest.approx(
+            fcst["yearly"][0] + fcst["weekly"][0] + fcst["extra_regressors_additive"][0]
+        )
+        assert fcst["multiplicative_terms"][0] == pytest.approx(
+            fcst["extra_regressors_multiplicative"][0]
+        )
+        assert fcst["yhat"][0] == pytest.approx(
+            fcst["trend"][0] * (1 + fcst["multiplicative_terms"][0]) + fcst["additive_terms"][0]
+        )
+
+    def test_constant_regressor(self, daily_univariate_ts, backend):
+        df = daily_univariate_ts.copy()
+        df["constant_feature"] = 0
+        m = Prophet(stan_backend=backend)
+        m.add_regressor("constant_feature")
+        m.fit(df)
+        assert m.extra_regressors["constant_feature"]["std"] == 1
+
+
+class TestProphetWarmStart:
+    def test_fit_warm_start(self, daily_univariate_ts, backend):
+        m = Prophet(stan_backend=backend).fit(daily_univariate_ts.iloc[:500])
+        m2 = Prophet(stan_backend=backend).fit(
+            daily_univariate_ts.iloc[:510], init=warm_start_params(m)
+        )
+        assert len(m2.params["delta"][0]) == 25
+
+    def test_sampling_warm_start(self, daily_univariate_ts, backend):
+        m = Prophet(mcmc_samples=100, stan_backend=backend).fit(
+            daily_univariate_ts.iloc[:500], show_progress=False
+        )
+        m2 = Prophet(mcmc_samples=100, stan_backend=backend).fit(
+            daily_univariate_ts.iloc[:510], init=warm_start_params(m), show_progress=False
+        )
+        assert m2.params["delta"].shape == (200, 25)

--- a/python/prophet/tests/test_serialize.py
+++ b/python/prophet/tests/test_serialize.py
@@ -3,35 +3,21 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import json
-import os
-import sys
-from unittest import TestCase, skipUnless
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import pytest
+
 from prophet import Prophet
-from prophet.serialize import model_to_json, model_from_json, PD_SERIES, PD_DATAFRAME
+from prophet.serialize import PD_DATAFRAME, PD_SERIES, model_from_json, model_to_json
 
 
-DATA = pd.read_csv(
-    os.path.join(os.path.dirname(__file__), 'data.csv'),
-    parse_dates=['ds'],
-)
-
-
-class TestSerialize(TestCase):
-
-    def test_simple_serialize(self):
-        m = Prophet()
-        days = 30
-        N = DATA.shape[0]
-        df = DATA.head(N - days)
+class TestSerialize:
+    def test_simple_serialize(self, daily_univariate_ts, backend):
+        m = Prophet(stan_backend=backend)
+        df = daily_univariate_ts.head(daily_univariate_ts.shape[0] - 30)
         m.fit(df)
 
         future = m.make_future_dataframe(2, include_history=False)
@@ -39,119 +25,118 @@ class TestSerialize(TestCase):
 
         model_str = model_to_json(m)
         # Make sure json doesn't get too large in the future
-        self.assertTrue(len(model_str) < 200000)
+        assert len(model_str) < 200000
         m2 = model_from_json(model_str)
 
         # Check that m and m2 are equal
-        self.assertEqual(m.__dict__.keys(), m2.__dict__.keys())
+        assert m.__dict__.keys() == m2.__dict__.keys()
         for k, v in m.__dict__.items():
-            if k in ['stan_fit', 'stan_backend']:
+            if k in ["stan_fit", "stan_backend"]:
                 continue
-            if k == 'params':
-                self.assertEqual(v.keys(), m2.params.keys())
+            if k == "params":
+                assert v.keys() == m2.params.keys()
                 for kk, vv in v.items():
-                    self.assertTrue(np.array_equal(vv, m2.params[kk]))
+                    assert np.array_equal(vv, m2.params[kk])
             elif k in PD_SERIES and v is not None:
-                self.assertTrue(v.equals(m2.__dict__[k]))
+                assert v.equals(m2.__dict__[k])
             elif k in PD_DATAFRAME and v is not None:
                 pd.testing.assert_frame_equal(v, m2.__dict__[k])
-            elif k == 'changepoints_t':
-                self.assertTrue(np.array_equal(v, m.__dict__[k]))
+            elif k == "changepoints_t":
+                assert np.array_equal(v, m.__dict__[k])
             else:
-                self.assertEqual(v, m2.__dict__[k])
-        self.assertTrue(m2.stan_fit is None)
-        self.assertTrue(m2.stan_backend is None)
+                assert v == m2.__dict__[k]
+        assert m2.stan_fit is None
+        assert m2.stan_backend is None
 
         # Check that m2 makes the same forecast
         future2 = m2.make_future_dataframe(2, include_history=False)
         fcst2 = m2.predict(future2)
 
-        self.assertTrue(np.array_equal(fcst['yhat'].values, fcst2['yhat'].values))
+        assert np.array_equal(fcst["yhat"].values, fcst2["yhat"].values)
 
-    def test_full_serialize(self):
+    def test_full_serialize(self, daily_univariate_ts, backend):
         # Construct a model with all attributes
-        holidays = pd.DataFrame({
-            'ds': pd.to_datetime(['2012-06-06', '2013-06-06']),
-            'holiday': ['seans-bday'] * 2,
-            'lower_window': [0] * 2,
-            'upper_window': [1] * 2,
-        })
+        holidays = pd.DataFrame(
+            {
+                "ds": pd.to_datetime(["2012-06-06", "2013-06-06"]),
+                "holiday": ["seans-bday"] * 2,
+                "lower_window": [0] * 2,
+                "upper_window": [1] * 2,
+            }
+        )
         # Test with holidays and country_holidays
         m = Prophet(
             holidays=holidays,
-            seasonality_mode='multiplicative',
-            changepoints=['2012-07-01', '2012-10-01', '2013-01-01'],
+            seasonality_mode="multiplicative",
+            changepoints=["2012-07-01", "2012-10-01", "2013-01-01"],
+            stan_backend=backend,
         )
-        m.add_country_holidays(country_name='US')
-        m.add_seasonality(name='conditional_weekly', period=7, fourier_order=3,
-                          prior_scale=2., condition_name='is_conditional_week')
-        m.add_seasonality(name='normal_monthly', period=30.5, fourier_order=5,
-                          prior_scale=2.)
-        df = DATA.copy()
-        df['is_conditional_week'] = [0] * 255 + [1] * 255
-        m.add_regressor('binary_feature', prior_scale=0.2)
-        m.add_regressor('numeric_feature', prior_scale=0.5)
-        m.add_regressor(
-            'numeric_feature2', prior_scale=0.5, mode='multiplicative'
+        m.add_country_holidays(country_name="US")
+        m.add_seasonality(
+            name="conditional_weekly",
+            period=7,
+            fourier_order=3,
+            prior_scale=2.0,
+            condition_name="is_conditional_week",
         )
-        m.add_regressor('binary_feature2', standardize=True)
-        df['binary_feature'] = ['0'] * 255 + ['1'] * 255
-        df['numeric_feature'] = range(510)
-        df['numeric_feature2'] = range(510)
-        df['binary_feature2'] = [1] * 100 + [0] * 410
+        m.add_seasonality(name="normal_monthly", period=30.5, fourier_order=5, prior_scale=2.0)
+        df = daily_univariate_ts.copy()
+        df["is_conditional_week"] = [0] * 255 + [1] * 255
+        m.add_regressor("binary_feature", prior_scale=0.2)
+        m.add_regressor("numeric_feature", prior_scale=0.5)
+        m.add_regressor("numeric_feature2", prior_scale=0.5, mode="multiplicative")
+        m.add_regressor("binary_feature2", standardize=True)
+        df["binary_feature"] = ["0"] * 255 + ["1"] * 255
+        df["numeric_feature"] = range(510)
+        df["numeric_feature2"] = range(510)
+        df["binary_feature2"] = [1] * 100 + [0] * 410
 
         train = df.head(400)
         test = df.tail(100)
 
         m.fit(train)
-        future = m.make_future_dataframe(periods=100, include_history=False)
         fcst = m.predict(test)
         # Serialize!
         m2 = model_from_json(model_to_json(m))
 
         # Check that m and m2 are equal
-        self.assertEqual(m.__dict__.keys(), m2.__dict__.keys())
+        assert m.__dict__.keys() == m2.__dict__.keys()
         for k, v in m.__dict__.items():
-            if k in ['stan_fit', 'stan_backend']:
+            if k in ["stan_fit", "stan_backend"]:
                 continue
-            if k == 'params':
-                self.assertEqual(v.keys(), m2.params.keys())
+            if k == "params":
+                assert v.keys() == m2.params.keys()
                 for kk, vv in v.items():
-                    self.assertTrue(np.array_equal(vv, m2.params[kk]))
+                    assert np.array_equal(vv, m2.params[kk])
             elif k in PD_SERIES and v is not None:
-                self.assertTrue(v.equals(m2.__dict__[k]))
+                assert v.equals(m2.__dict__[k])
             elif k in PD_DATAFRAME and v is not None:
                 pd.testing.assert_frame_equal(v, m2.__dict__[k])
-            elif k == 'changepoints_t':
-                self.assertTrue(np.array_equal(v, m.__dict__[k]))
+            elif k == "changepoints_t":
+                assert np.array_equal(v, m.__dict__[k])
             else:
-                self.assertEqual(v, m2.__dict__[k])
-        self.assertTrue(m2.stan_fit is None)
-        self.assertTrue(m2.stan_backend is None)
+                assert v == m2.__dict__[k]
+        assert m2.stan_fit is None
+        assert m2.stan_backend is None
 
         # Check that m2 makes the same forecast
-        future = m2.make_future_dataframe(periods=100, include_history=False)
         fcst2 = m2.predict(test)
-
-        self.assertTrue(np.array_equal(fcst['yhat'].values, fcst2['yhat'].values))
+        assert np.array_equal(fcst["yhat"].values, fcst2["yhat"].values)
 
     def test_backwards_compatibility(self):
         old_versions = {
-            '0.6.1.dev0': (29.3669923968994, 'fb'),
-            '0.7.1': (29.282810844704414, 'fb'),
-            '1.0.1': (29.282810844704414, ''),
+            "0.6.1.dev0": (29.3669923968994, "fb"),
+            "0.7.1": (29.282810844704414, "fb"),
+            "1.0.1": (29.282810844704414, ""),
         }
         for v, (pred_val, v_str) in old_versions.items():
-            fname = os.path.join(
-                os.path.dirname(__file__),
-                'serialized_model_v{}.json'.format(v)
-            )
-            with open(fname, 'r') as fin:
+            fname = Path(__file__).parent / f"serialized_model_v{v}.json"
+            with open(fname, "r") as fin:
                 model_str = json.load(fin)
             # Check that deserializes
             m = model_from_json(model_str)
-            self.assertEqual(json.loads(model_str)[f'__{v_str}prophet_version'], v)
+            assert json.loads(model_str)[f"__{v_str}prophet_version"] == v
             # Predict
             future = m.make_future_dataframe(10)
             fcst = m.predict(future)
-            self.assertAlmostEqual(fcst['yhat'].values[-1], pred_val)
+            assert fcst["yhat"].values[-1] == pytest.approx(pred_val)

--- a/python/prophet/tests/test_utilities.py
+++ b/python/prophet/tests/test_utilities.py
@@ -3,39 +3,25 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-import os
-from unittest import TestCase
-
 import numpy as np
-import pandas as pd
+
 from prophet import Prophet
 from prophet.utilities import regressor_coefficients
 
 
-DATA = pd.read_csv(
-    os.path.join(os.path.dirname(__file__), 'data.csv'),
-    parse_dates=['ds'],
-)
-
-class TestUtilities(TestCase):
-    def test_regressor_coefficients(self):
-        m = Prophet()
-        N = DATA.shape[0]
-        df = DATA.copy()
+class TestUtilities:
+    def test_regressor_coefficients(self, daily_univariate_ts, backend):
+        m = Prophet(stan_backend=backend)
+        df = daily_univariate_ts.copy()
         np.random.seed(123)
-        df['regr1'] = np.random.normal(size=N)
-        df['regr2'] = np.random.normal(size=N)
-        m.add_regressor('regr1', mode='additive')
-        m.add_regressor('regr2', mode='multiplicative')
+        df["regr1"] = np.random.normal(size=df.shape[0])
+        df["regr2"] = np.random.normal(size=df.shape[0])
+        m.add_regressor("regr1", mode="additive")
+        m.add_regressor("regr2", mode="multiplicative")
         m.fit(df)
 
         coefs = regressor_coefficients(m)
-        self.assertTrue(coefs.shape == (2, 6))
+        assert coefs.shape == (2, 6)
         # No MCMC sampling, so lower and upper should be the same as mean
-        self.assertTrue(np.array_equal(coefs['coef_lower'].values, coefs['coef'].values))
-        self.assertTrue(np.array_equal(coefs['coef_upper'].values, coefs['coef'].values))
+        assert np.array_equal(coefs["coef_lower"].values, coefs["coef"].values)
+        assert np.array_equal(coefs["coef_upper"].values, coefs["coef"].values)


### PR DESCRIPTION
## Changes

* Use `pytest` style assertions, fixtures, and parametrization.
* Broke up tests into different classes and functions for a clearer grouping of what functionality is being tested.
* Added `backend` argument to all calls to `Prophet()`, which allows us to test end-to-end with any new backends (e.g. https://github.com/facebook/prophet/pull/1973).
  * Note that the `backend` parametrization is done with `pytest_generate_tests()`, which re-runs all tests with the specified backend  argument.
  * This is not the most efficient, since some tests (e.g. fourier series, piecewise function outputs) do not rely on the PPL backend. However, it is easier to manage (we don't need to consider which tests would / wouldn't require a parametrization), and allows us to catch unintended interactions between intermediate outputs and the inputs to the PPL backend.

## Local testing
```
❯ pipenv run python -m pytest prophet/tests/ --backend CMDSTANPY
========================================== test session starts ==========================================
platform linux -- Python 3.8.6, pytest-7.2.1, pluggy-1.0.0
rootdir: /media/storage/cuong/github/prophet/python
plugins: anyio-3.6.1
collected 69 items                                                                                      

prophet/tests/test_diagnostics.py ..................                                              [ 26%]
prophet/tests/test_prophet.py ..s..s.........................................                     [ 94%]
prophet/tests/test_serialize.py ...                                                               [ 98%]
prophet/tests/test_utilities.py .                                                                 [100%]

============================== 67 passed, 2 skipped, 6 warnings in 34.04s ===============================
```