### PR TITLE
Updated documentation and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,11 @@ After installation, you can [get started!](https://facebook.github.io/prophet/do
 
 ### Anaconda
 
-Prophet can also be installed through conda-forge: `conda install -c conda-forge prophet`.
+Prophet can also be installed through conda-forge.
+
+```bash
+conda install -c conda-forge prophet
+```
 
 ## Installation in Python - Development version
 

--- a/docs/_docs/installation.md
+++ b/docs/_docs/installation.md
@@ -69,6 +69,7 @@ After installation, you can [get started!](quick_start.html#python-api)
 ### Anaconda
 
 Prophet can also be installed through conda-forge.
+
 ```bash
 conda install -c conda-forge prophet
 ```

--- a/docs/_docs/installation.md
+++ b/docs/_docs/installation.md
@@ -68,4 +68,7 @@ After installation, you can [get started!](quick_start.html#python-api)
 
 ### Anaconda
 
-Prophet can also be installed through conda-forge: `conda install -c conda-forge prophet`.
+Prophet can also be installed through conda-forge.
+```bash
+conda install -c conda-forge prophet
+```


### PR DESCRIPTION
While installing prophet through anaconda there was no option to copy the command , like there was for other ways of installation through python or R.

I have fixed that by updating both the README and documentation. Tested the development locally and It was working perfectly.