### PR TITLE
Update check config for R Github Actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -59,6 +59,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - uses: r-lib/actions/setup-pandoc@v2
     - name: Set up R
       uses: r-lib/actions/setup-r@v2
       with:
@@ -93,15 +94,6 @@ jobs:
         install.packages(c("cmdstanr", "posterior"), repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
       shell: Rscript {0}
     - name: Check
-      env:
-        _R_CHECK_CRAN_INCOMING_REMOTE_: false
-      run: |
-        options(crayon.enabled = TRUE)
-        rcmdcheck::rcmdcheck(path = "R/", args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
-      shell: Rscript {0}
-    - name: Upload check results
-      if: failure()
-      uses: actions/upload-artifact@main
+      uses: r-lib/actions/check-r-package@v2
       with:
-        name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-        path: check
+        upload-snapshots: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -96,4 +96,5 @@ jobs:
     - name: Check
       uses: r-lib/actions/check-r-package@v2
       with:
+        working-directory: "R/"
         upload-snapshots: true


### PR DESCRIPTION
R workflow is currently failing at the check step due to missing pandoc dependency. We update the workflow based on the new standard CI template here: https://github.com/r-lib/actions/tree/v2/examples#standard-ci-workflow

Will merge if R workflow passes.