### PR TITLE
Correct R install command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ After installation, you can [get started!](https://facebook.github.io/prophet/do
 
 ```r
 install.packages('remotes')
-remotes::install_github('facebook/prophet@*release')
+remotes::install_github('facebook/prophet@*release', subdir = 'R')
 ```
 
 #### Experimental backend - cmdstanr


### PR DESCRIPTION
Correct command to install R package from github. The command in the current version of the README returns the error: "Does not appear to be an R package (no DESCRIPTION)".

Adding the argument `subdir = 'R'` tells the `install_github` function where to find the DESCRIPTION file/R package.