### PR TITLE
Bug Fix: Include predictions for missing y (NaN) dates in the history #2518

### DIFF
--- a/python/prophet/forecaster.py
+++ b/python/prophet/forecaster.py
@@ -1130,7 +1130,7 @@ class Prophet(object):
         history = df[df['y'].notnull()].copy()
         if history.shape[0] < 2:
             raise ValueError('Dataframe has less than 2 non-NaN rows.')
-        self.history_dates = pd.to_datetime(pd.Series(history['ds'].unique(), name='ds')).sort_values()
+        self.history_dates = pd.to_datetime(pd.Series(df['ds'].unique(), name='ds')).sort_values()
 
         self.history = self.setup_dataframe(history, initialize_scales=True)
         self.set_auto_seasonalities()

--- a/python/prophet/tests/test_prophet.py
+++ b/python/prophet/tests/test_prophet.py
@@ -244,6 +244,16 @@ class TestProphetDataPrep:
         assert len(future) == 3
         assert np.all(future["ds"].values == correct.values)
 
+    def test_make_future_dataframe_include_history(self, daily_univariate_ts, backend):
+        train = daily_univariate_ts.head(468 // 2).copy()
+        #cover history with NAs
+        train.loc[train.sample(10).index, "y"] = np.nan
+        
+        forecaster = Prophet(stan_backend=backend)
+        forecaster.fit(train)
+        future = forecaster.make_future_dataframe(periods=3, freq="D", include_history=True)
+
+        assert len(future) == train.shape[0] + 3
 
 class TestProphetTrendComponent:
     def test_invalid_growth_input(self, backend):


### PR DESCRIPTION
In the 1.1.5 version, `make_future_dataframe()` **ignores** the missing `y` values in the history.
As a consequence, the model **will not calculate** predictions for those dates in the history.

This is fixed by replacing [this line](https://github.com/facebook/prophet/blob/c00f6a2d72229faa6acee8292bc01e14f16f599c/python/prophet/forecaster.py#L1133):
```python
self.history_dates = pd.to_datetime(pd.Series(history['ds'].unique(), name='ds')).sort_values()`
```
by:
```python
self.history_dates = pd.to_datetime(pd.Series(df['ds'].unique(), name='ds')).sort_values()
```

Fixes #2518 