### PR TITLE
Use stable sort when sorting values in forecaster

### DIFF
--- a/python/prophet/forecaster.py
+++ b/python/prophet/forecaster.py
@@ -320,7 +320,7 @@ class Prophet(object):
 
         if df.index.name == 'ds':
             df.index.name = None
-        df = df.sort_values('ds')
+        df = df.sort_values('ds', kind='mergesort')
         df = df.reset_index(drop=True)
 
         self.initialize_scales(initialize_scales, df)


### PR DESCRIPTION
When Prophet prepares a dataframe for fitting or predicting, it runs a sort on the `ds` column.

This changes the sort algorithm from the pandas default sort to mergesort, which is a stable sort.

This is important in situations where multiple regressors are present and so the fitted dataframe is not unique by date.

Users may do something like the following:

```.py
df = <some dataframe>
# Example df
# ds            x   y   
# 2020-01-01    0   3.2
# 2020-01-01    1   4.1
# 2020-01-02    0   3.7
# 2020-01-02    1   4.3

m = Prophet()
m.add_regressor('x')
m.fit(df)

predict_df = m.predict(df)
df['prediction'] = predict_df['yhat']
```

In `m.predict(df)`, there is a call to `df.sort_values('ds')`. As this is not a stable sort, sometimes the `x` column above can get switched around, even if `df` is sorted. A stable sort addresses this.

This partially addresses #2322 if you construct the input correctly.