### PR TITLE
Fix Issue #2577 - Zero Division Error in diagnostics.performance_metrics() causing failed assertion

### DIFF
--- a/python/prophet/diagnostics.py
+++ b/python/prophet/diagnostics.py
@@ -630,6 +630,7 @@ def smape(df, w):
     Dataframe with columns horizon and smape.
     """
     sape = np.abs(df['y'] - df['yhat']) / ((np.abs(df['y']) + np.abs(df['yhat'])) / 2)
+    sape = sape.fillna(0)
     if w < 0:
         return pd.DataFrame({'horizon': df['horizon'], 'smape': sape})
     return rolling_mean_by_h(

--- a/python/prophet/tests/test_diagnostics.py
+++ b/python/prophet/tests/test_diagnostics.py
@@ -234,7 +234,9 @@ class TestPerformanceMetrics:
             metrics=["coverage", "mse"],
         )
         assert set(df_horizon.columns) == {"coverage", "mse", "horizon"}
-        # Handle zero y and yhat and skip MAPE
+        # Skip MAPE
+        df_cv.loc[0, "y"] = 0.0
+        # Handle zero y and yhat
         df_cv["y"] = 0.0
         df_cv["yhat"] = 0.0
         df_horizon = diagnostics.performance_metrics(

--- a/python/prophet/tests/test_diagnostics.py
+++ b/python/prophet/tests/test_diagnostics.py
@@ -236,6 +236,11 @@ class TestPerformanceMetrics:
         assert set(df_horizon.columns) == {"coverage", "mse", "horizon"}
         # Skip MAPE
         df_cv.loc[0, "y"] = 0.0
+        df_horizon = diagnostics.performance_metrics(
+            df_cv,
+            metrics=["coverage", "mape"],
+        )
+        assert set(df_horizon.columns) == {"coverage", "horizon"}
         # Handle zero y and yhat
         df_cv["y"] = 0.0
         df_cv["yhat"] = 0.0

--- a/python/prophet/tests/test_diagnostics.py
+++ b/python/prophet/tests/test_diagnostics.py
@@ -234,13 +234,13 @@ class TestPerformanceMetrics:
             metrics=["coverage", "mse"],
         )
         assert set(df_horizon.columns) == {"coverage", "mse", "horizon"}
-        # Skip MAPE
-        df_cv.loc[0, "y"] = 0.0
+        # Handle zero y and yhat and skip MAPE
+        df_cv["y"] = 0.0
+        df_cv["yhat"] = 0.0
         df_horizon = diagnostics.performance_metrics(
             df_cv,
-            metrics=["coverage", "mape"],
         )
-        assert set(df_horizon.columns) == {"coverage", "horizon"}
+        assert set(df_horizon.columns) == {"coverage", "horizon", "mae", "mdape", "mse", "rmse", "smape"}
         df_horizon = diagnostics.performance_metrics(
             df_cv,
             metrics=["mape"],


### PR DESCRIPTION
This PR resolves Issue #2577 

This issue is caused by zero division leading to `np.nan` values, so this PR adds a fix by filling `np.nan` values with zero during the calculation of the SMAPE metric.

This PR also updates the `test_performance_metrics()` method in the `TestPerformanceMetrics` class in `tests.test_diagnostics.py` to cover all metrics handling zero values for `y` and `yhat`.