### PR TITLE
fix typo

### DIFF
--- a/python/prophet/__init__.py
+++ b/python/prophet/__init__.py
@@ -12,3 +12,4 @@ here = Path(__file__).parent.resolve()
 with open(here / "__version__.py", "r") as f:
     exec(f.read(), about)
 __version__ = about["__version__"]
+__all__ = ["Prophet"]

--- a/python/prophet/tests/test_diagnostics.py
+++ b/python/prophet/tests/test_diagnostics.py
@@ -348,9 +348,9 @@ class TestProphetCopy:
                 assert m1.changepoints == m2.changepoints
             else:
                 assert m1.changepoints.equals(m2.changepoints)
-            assert False == m2.yearly_seasonality
-            assert False == m2.weekly_seasonality
-            assert False == m2.daily_seasonality
+            assert m2.yearly_seasonality is False
+            assert m2.weekly_seasonality is False
+            assert m2.daily_seasonality is False
             assert m1.yearly_seasonality == ("yearly" in m2.seasonalities)
             assert m1.weekly_seasonality == ("weekly" in m2.seasonalities)
             assert m1.daily_seasonality == ("daily" in m2.seasonalities)

--- a/python_shim/fbprophet/__init__.py
+++ b/python_shim/fbprophet/__init__.py
@@ -13,3 +13,5 @@ logger.warning(
     'As of v1.0, the package name has changed from "fbprophet" to "prophet". '
     'Please update references in your code accordingly.'
 )
+
+__all__ = ["Prophet"]


### PR DESCRIPTION
- 1 - Add unused imports in `__init__.py` into `__all__` to be used.
- 2 - use `assert value is False` instead of equality.