### PR TITLE
fix-numpy-2.0-compatibility

### DIFF
--- a/python/prophet/forecaster.py
+++ b/python/prophet/forecaster.py
@@ -456,7 +456,7 @@ class Prophet(object):
         dates: pd.Series,
         period: Union[int, float],
         series_order: int,
-    ) -> NDArray[np.float_]:
+    ) -> NDArray[np.float64]:
         """Provides Fourier series components with the specified frequency
         and order.
 


### PR DESCRIPTION
Fixed compatibility with NumPy 2.0 by replacing np.float_ with np.float64