### PR TITLE
numpy needs to be older than 2.0 version

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
   "cmdstanpy>=1.0.4",
-  "numpy>=1.15.4",
+  "numpy>=1.15.4,<2.0.0",
   "matplotlib>=2.0.0",
   "pandas>=1.0.4",
   "holidays>=0.25",


### PR DESCRIPTION
np.float_ was removed in the NumPy 2.0 release. Use np.float64.