### PR TITLE
New parameter added in order to replace negative predictions with 0

### DIFF
--- a/python/prophet/forecaster.py
+++ b/python/prophet/forecaster.py
@@ -78,7 +78,7 @@ class Prophet(object):
     stan_backend: str as defined in StanBackendEnum default: None - will try to
         iterate over all available backends and find the working one
     holidays_mode: 'additive' or 'multiplicative'. Defaults to seasonality_mode.
-    negative_values: bool check to set all yhat_lower negative prediction values in the DataFrame to 0.
+    negative_prediction_values: bool check to set all yhat_lower negative prediction values in the DataFrame to 0.
     """
 
     def __init__(

--- a/python/prophet/forecaster.py
+++ b/python/prophet/forecaster.py
@@ -1454,10 +1454,7 @@ class Prophet(object):
             if component in self.component_modes['additive']:
                 comp *= self.y_scale
 
-            if self.negative_prediction_values:
-                data[component] = np.nanmean(comp, axis=1)
-            else:
-                data[component] = np.clip(np.nanmean(comp, axis=1), a_min=0, a_max=None)
+            data[component] = np.nanmean(comp, axis=1)
 
             if self.uncertainty_samples:
                 self.calculate_and_clip_percentile(

--- a/python/prophet/forecaster.py
+++ b/python/prophet/forecaster.py
@@ -1461,8 +1461,11 @@ class Prophet(object):
             data[component] = np.nanmean(comp, axis=1)
 
             if self.uncertainty_samples:
-                self.calculate_and_clip_percentile(
-                    data, component, comp, lower_p, upper_p
+                data[component + '_lower'] = self.percentile(
+                    comp, lower_p, axis=1,
+                )
+                data[component + '_upper'] = self.percentile(
+                    comp, upper_p, axis=1,
                 )
 
         return pd.DataFrame(data)

--- a/python/prophet/forecaster.py
+++ b/python/prophet/forecaster.py
@@ -78,7 +78,7 @@ class Prophet(object):
     stan_backend: str as defined in StanBackendEnum default: None - will try to
         iterate over all available backends and find the working one
     holidays_mode: 'additive' or 'multiplicative'. Defaults to seasonality_mode.
-    negative_prediction_values: bool check to set all yhat_lower negative prediction values in the DataFrame to 0.
+    negative_prediction_values: bool check to set all negative prediction values in the DataFrame to 0.
     """
 
     def __init__(

--- a/python/prophet/forecaster.py
+++ b/python/prophet/forecaster.py
@@ -1326,6 +1326,10 @@ class Prophet(object):
                 df2['trend'] * (1 + df2['multiplicative_terms'])
                 + df2['additive_terms']
         )
+
+        if not self.negative_prediction_values:
+            df2['yhat'] = df2['yhat'].clip(lower=0)
+
         return df2
 
     @staticmethod

--- a/python/prophet/tests/test_prophet.py
+++ b/python/prophet/tests/test_prophet.py
@@ -434,21 +434,15 @@ class TestProphetTrendComponent:
         cp = m.changepoints_t
         assert cp.shape[0] == 15
 
-    @pytest.mark.parametrize(
-        "expected",
-        [5.656087514685135],
-    )
-    def test_without_negative_predictions(self, subdaily_univariate_ts, backend, expected):
+    def test_without_negative_predictions(self, subdaily_univariate_ts, backend):
         test_days = 280
         train, test = train_test_split(subdaily_univariate_ts, test_days)
-        forecaster = Prophet(stan_backend=backend, negative_prediction_values=False)
+        forecaster = Prophet(stan_backend=backend, negative_prediction_values=False, weekly_seasonality=True, yearly_seasonality=True)
         forecaster.fit(train, seed=1237861298)
         np.random.seed(876543987)
         future = forecaster.make_future_dataframe(test_days, include_history=False)
         future = forecaster.predict(future)
-        res = rmse(future["yhat"], test["y"])
-        tolerance = 1e-5
-        assert res == pytest.approx(expected, rel=tolerance), "backend: {}".format(forecaster.stan_backend)
+        assert (future['yhat'].values >= 0).all()
 
 
 class TestProphetSeasonalComponent:

--- a/python/prophet/tests/test_prophet.py
+++ b/python/prophet/tests/test_prophet.py
@@ -30,7 +30,7 @@ class TestProphetFitPredictDefault:
     def test_fit_predict(self, daily_univariate_ts, backend, scaling, expected):
         test_days = 30
         train, test = train_test_split(daily_univariate_ts, test_days)
-        forecaster = Prophet(stan_backend=backend, scaling=scaling)
+        forecaster = Prophet(stan_backend=backend, scaling=scaling, negative_prediction_values=False)
         forecaster.fit(train, seed=1237861298)
         np.random.seed(876543987)
         future = forecaster.make_future_dataframe(test_days, include_history=False)

--- a/python/prophet/tests/test_prophet.py
+++ b/python/prophet/tests/test_prophet.py
@@ -30,7 +30,7 @@ class TestProphetFitPredictDefault:
     def test_fit_predict(self, daily_univariate_ts, backend, scaling, expected):
         test_days = 30
         train, test = train_test_split(daily_univariate_ts, test_days)
-        forecaster = Prophet(stan_backend=backend, scaling=scaling, negative_prediction_values=False)
+        forecaster = Prophet(stan_backend=backend, scaling=scaling)
         forecaster.fit(train, seed=1237861298)
         np.random.seed(876543987)
         future = forecaster.make_future_dataframe(test_days, include_history=False)


### PR DESCRIPTION
Sometimes, data series contain many values close to zero but are not expected to fall below zero. For example, a data frame with response times will likely have many near-zero values. In such cases, Prophet may produce yhat_lower or trend_lower metric values that are negative.

To address this issue, I have implemented a flag that sets **_trend, yhat, yhat lower and yhat upper_** values to zero in the future data frame. This flag can be configured when defining the model.