### PR TITLE
Fix bug with `yearly.seasonality = 1`

### DIFF
--- a/R/R/prophet.R
+++ b/R/R/prophet.R
@@ -1003,9 +1003,9 @@ parse_seasonality_args <- function(m, name, arg, auto.disable, default.order) {
     } else {
       fourier.order <- default.order
     }
-  } else if (arg == TRUE) {
+  } else if (isTRUE(arg)) {
     fourier.order <- default.order
-  } else if (arg == FALSE) {
+  } else if (isFALSE(arg)) {
     fourier.order <- 0
   } else {
     fourier.order <- arg


### PR DESCRIPTION
Hi,

I'm trying to create a lesson plan for my class teaching them intuition on how `prophet` works. One thing I want to do is set `yearly.seasonality = 0`, then `1` so they can see how the plot components vary (and see the Fourier terms). But, there's a small bug in the code that checks `arg == TRUE` which returns TRUE when `arg == 1`. Switching to `isTRUE()` fixes this