### PR TITLE
perf: Make validation check in regressor_column_matrix 300x faster

### DIFF
--- a/python/prophet/forecaster.py
+++ b/python/prophet/forecaster.py
@@ -905,8 +905,8 @@ class Prophet(object):
         # Remove the placeholder
         component_cols.drop('zeros', axis=1, inplace=True, errors='ignore')
         # Validation
-        if (max(component_cols['additive_terms']
-            + component_cols['multiplicative_terms']) > 1):
+        if ((component_cols['additive_terms']
+            + component_cols['multiplicative_terms']).max() > 1):
             raise Exception('A bug occurred in seasonal components.')
         # Compare to the training, if set.
         if self.train_component_cols is not None:


### PR DESCRIPTION
This is something I've noticed on the way towards https://github.com/facebook/prophet/issues/2622 (which may not be that far off!)

The builtin Python `max` would need to iterate over elements, which is much slower than calling the native `Series.max` (where the algorithm would be in a low-level language)

Example:
```python
In [43]: s = pd.Series(rng.integers(0, 10, size=1_000_000))

In [44]: %timeit max(s) > 1
65.4 ms ± 5.59 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [45]: %timeit s.max() > 1
221 μs ± 16.5 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```