### PR TITLE
Update dyplot.prophet in plot.R

### DIFF
--- a/R/R/plot.R
+++ b/R/R/plot.R
@@ -470,7 +470,7 @@ dyplot.prophet <- function(x, fcst, uncertainty=TRUE,
     forecastCols <- c('yhat')
   }
   # convert to xts for easier date handling by dygraph
-  dfTS <- xts::xts(df %>% dplyr::select_(.dots=colsToKeep), order.by = df$ds)
+  dfTS <- xts::xts(df %>% dplyr::select(.dots=colsToKeep), order.by = df$ds)
 
   # base plot
   dyBase <- dygraphs::dygraph(dfTS, ...)


### PR DESCRIPTION
Changed select_() to select() since deprecated in dplyr 0.7.0.