### PR TITLE
Set package SystemRequirements to C++14 and add placeholder Maintainer

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -14,6 +14,7 @@ Description: Implements a procedure for forecasting time series data based on
     handles outliers well.
 URL: https://github.com/facebook/prophet
 BugReports: https://github.com/facebook/prophet/issues
+Maintainer: TODO <maintainer@example.com>
 Depends:
     R (>= 3.4.0),
     Rcpp (>= 0.12.0),
@@ -41,7 +42,7 @@ Suggests:
     testthat,
     readr,
     rmarkdown
-SystemRequirements: GNU make, C++11
+SystemRequirements: GNU make, C++14
 Biarch: true
 License: MIT + file LICENSE
 LinkingTo:


### PR DESCRIPTION
Proposed fix after receiving this email from CRAN and reported via https://github.com/facebook/prophet/issues/2702:

```
CRAN package prophet specifies C++11 which has been deprecated for
almost three years and is about to be withdrawn.  Email to its
maintainer is undeliverable.

Thus, package prophet is now scheduled for archival on 2026-01-29,
and archiving this will necessitate also archiving its CRAN strong
reverse dependencies.  Those are

Robyn autoTS bayesforecast fable.prophet modeltime promotionImpact
ForecastingEnsembles LLMAgentR finnts healthyR.ai modeltime.ensemble
modeltime.resample


Please negotiate the necessary actions.
```

Please note the maintainer must be included in the placeholder before submitting to CRAN.