### PR TITLE
fix: constrain numpy

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.12"]
         os:
           - macos-14-large # Intel
           - macos-14-xlarge # ARM64

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
   "cmdstanpy>=1.0.4",
-  "numpy>=1.15.4",
+  "numpy>=1.15.4,<2.4.0",
   "matplotlib>=2.0.0",
   "pandas>=1.0.4,<3",
   "holidays>=0.25,<1",


### PR DESCRIPTION
- Implicit conversion of an array to a scalar has been deprecated in numpy and was removed in v2.4. Constrain the version for a patch release. Proper fix to follow.
- We haven't caught this because our tests run on Python 3.10, which numpy stopped publishing wheels for as of v2.3. Update the CI to run on Python 3.12, as that's the most common Python version at the moment.