### PR TITLE
simplified `__init__.py`

### DIFF
--- a/python/prophet/__init__.py
+++ b/python/prophet/__init__.py
@@ -4,11 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
+
+from prophet.__version__ import __version__
 from prophet.forecaster import Prophet
 
-from pathlib import Path
-about = {}
-here = Path(__file__).parent.resolve()
-with open(here / "__version__.py", "r") as f:
-    exec(f.read(), about)
-__version__ = about["__version__"]
+__all__ = ["Prophet", "__version__"]


### PR DESCRIPTION
Instead of manually parsing and executing the `__version__.py` module to obtain the `__version__` constant, it can also simply be imported

I also took the liberty of adding an `__all__`, because I figured that explicit is better than implicit :)