### PR TITLE
fix(forecaster): correct 'occured' -> 'occurred' in slope-delta helper docstring

### DIFF
--- a/python/prophet/forecaster.py
+++ b/python/prophet/forecaster.py
@@ -1892,7 +1892,7 @@ class Prophet:
         np.ndarray[tuple[int], np.dtype[np.float64]],
     ]:
         """
-        Creates a matrix of slope-deltas where these changes occured in training data according to the trained prophet obj
+        Creates a matrix of slope-deltas where these changes occurred in training data according to the trained prophet obj
         """
         if single_diff is None:
             single_diff = np.diff(t_time).mean()


### PR DESCRIPTION
Docstring inside the slope-delta matrix helper at `python/prophet/forecaster.py:1895` used `changes occured in training data`. Doc-only change; `ast.parse` stays clean against current `main`.