### PR TITLE
Update outdated license info in python init file (Fixes #2728)

### DIFF
--- a/python/prophet/__init__.py
+++ b/python/prophet/__init__.py
@@ -1,9 +1,7 @@
-# Copyright (c) 2017-present, Facebook, Inc.
-# All rights reserved.
+# Copyright (c) Facebook, Inc. and its affiliates.
 #
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree. An additional grant
-# of patent rights can be found in the PATENTS file in the same directory.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from prophet.__version__ import __version__
 from prophet.forecaster import Prophet


### PR DESCRIPTION
Fixes facebook/prophet#2728 by updating the old BSD-style license header in `python/prophet/__init__.py` to match the MIT license used in the rest of the project.