### PR TITLE
fix: properly shut down executor pools in cross_validation to prevent…

### DIFF
--- a/python/prophet/diagnostics.py
+++ b/python/prophet/diagnostics.py
@@ -212,15 +212,18 @@ def cross_validation(
 
     if parallel:
         valid = {"threads", "processes", "dask"}
+        _owns_pool = False
 
         if parallel == "threads":
             pool = concurrent.futures.ThreadPoolExecutor()
+            _owns_pool = True
         elif parallel == "processes":
             if sys.platform.startswith("win") or sys.platform == "darwin":
                 ctx = multiprocessing.get_context("spawn")
             else:
                 ctx = multiprocessing.get_context("forkserver")
             pool = concurrent.futures.ProcessPoolExecutor(mp_context=ctx)
+            _owns_pool = True
         elif parallel == "dask":
             try:
                 from dask.distributed import get_client
@@ -242,10 +245,14 @@ def cross_validation(
         iterables = zip(*iterables)
 
         logger.info("Applying in parallel with %s", pool)
-        predicts = pool.map(single_cutoff_forecast, *iterables)
-        if parallel == "dask":
-            # convert Futures to DataFrames
-            predicts = cast("dd.Client", pool).gather(predicts)
+        try:
+            predicts = pool.map(single_cutoff_forecast, *iterables)
+            if parallel == "dask":
+                # convert Futures to DataFrames
+                predicts = cast("dd.Client", pool).gather(predicts)
+        finally:
+            if _owns_pool:
+                pool.shutdown(wait=True)
 
     else:
         predicts = [


### PR DESCRIPTION

## Fix

Track whether the pool was created internally (`_owns_pool` flag) and shut it down in a `try/finally` block after `pool.map()` completes. User-provided pools (via `hasattr(parallel, "map")`) and dask clients are left untouched — we didn't create them, so we shouldn't close them.

## Changes

`python/prophet/diagnostics.py`: +11/-4 lines

- Add `_owns_pool = False` flag at the start of the parallel block
- Set `_owns_pool = True` for internally-created `ThreadPoolExecutor` and `ProcessPoolExecutor`
- Wrap `pool.map()` + dask gather in `try/finally` that calls `pool.shutdown(wait=True)` when `_owns_pool`

## Behavior

| `parallel=` | Pool created by us? | Shut down after use? |
|---|---|---|
| `'processes'` | Yes | Yes (new) |
| `'threads'` | Yes | Yes (new) |
| `'dask'` | No (existing client) | No (unchanged) |
| custom object with `.map()` | No (user-provided) | No (unchanged) |

## Why `try/finally` over `with` statement

The pool creation happens across 4 different branches (threads/processes/dask/custom). Using a context manager would require either restructuring all branches, a factory function, or `contextlib.nullcontext` for non-owned pools — all more invasive than the 5-line flag approach.

## Testing

Verified with 11 tests (mocked, no CmdStan required):
1. `ProcessPoolExecutor.shutdown(wait=True)` called on success
2. `ThreadPoolExecutor.shutdown(wait=True)` called on success
3. `shutdown()` called even when `pool.map()` raises (try/finally)
4. Custom user-provided pool is NOT shut down
5. 10 repeated calls all properly shut down (no FD accumulation)
6. `shutdown()` exception propagates correctly
7. `KeyboardInterrupt` during `map()` — finally still runs
8. Dask client NOT shut down
9. Lazy iterator from `map()` safe to consume after shutdown
10. Generator consumed by `pd.concat` works after shutdown
11. Real `ThreadPoolExecutor` over 20 iterations: 0 FDs leaked
