### PR TITLE
fix: close cross-validation executor pools

### DIFF
--- a/python/prophet/diagnostics.py
+++ b/python/prophet/diagnostics.py
@@ -212,15 +212,18 @@ def cross_validation(
 
     if parallel:
         valid = {"threads", "processes", "dask"}
+        _owns_pool = False
 
         if parallel == "threads":
             pool = concurrent.futures.ThreadPoolExecutor()
+            _owns_pool = True
         elif parallel == "processes":
             if sys.platform.startswith("win") or sys.platform == "darwin":
                 ctx = multiprocessing.get_context("spawn")
             else:
                 ctx = multiprocessing.get_context("forkserver")
             pool = concurrent.futures.ProcessPoolExecutor(mp_context=ctx)
+            _owns_pool = True
         elif parallel == "dask":
             try:
                 from dask.distributed import get_client
@@ -228,6 +231,7 @@ def cross_validation(
                 raise ImportError("parallel='dask' requires the optional "
                                   "dependency dask.") from e
             pool = get_client()
+            # get_client() returns a client managed by the caller.
             # delay df and model to avoid large objects in task graph.
             df, model = pool.scatter([df, model])
         elif hasattr(parallel, "map"):
@@ -242,10 +246,14 @@ def cross_validation(
         iterables = zip(*iterables)
 
         logger.info("Applying in parallel with %s", pool)
-        predicts = pool.map(single_cutoff_forecast, *iterables)
-        if parallel == "dask":
-            # convert Futures to DataFrames
-            predicts = cast("dd.Client", pool).gather(predicts)
+        try:
+            predicts = pool.map(single_cutoff_forecast, *iterables)
+            if parallel == "dask":
+                # convert Futures to DataFrames
+                predicts = cast("dd.Client", pool).gather(predicts)
+        finally:
+            if _owns_pool:
+                pool.shutdown(wait=True)
 
     else:
         predicts = [

--- a/python/prophet/diagnostics.py
+++ b/python/prophet/diagnostics.py
@@ -212,18 +212,15 @@ def cross_validation(
 
     if parallel:
         valid = {"threads", "processes", "dask"}
-        _owns_pool = False
 
         if parallel == "threads":
             pool = concurrent.futures.ThreadPoolExecutor()
-            _owns_pool = True
         elif parallel == "processes":
             if sys.platform.startswith("win") or sys.platform == "darwin":
                 ctx = multiprocessing.get_context("spawn")
             else:
                 ctx = multiprocessing.get_context("forkserver")
             pool = concurrent.futures.ProcessPoolExecutor(mp_context=ctx)
-            _owns_pool = True
         elif parallel == "dask":
             try:
                 from dask.distributed import get_client
@@ -252,7 +249,10 @@ def cross_validation(
                 # convert Futures to DataFrames
                 predicts = cast("dd.Client", pool).gather(predicts)
         finally:
-            if _owns_pool:
+            if (
+                parallel in ("threads", "processes")
+                and isinstance(pool, concurrent.futures.Executor)
+            ):
                 pool.shutdown(wait=True)
 
     else:

--- a/python/prophet/tests/test_diagnostics.py
+++ b/python/prophet/tests/test_diagnostics.py
@@ -5,6 +5,7 @@
 
 import datetime
 import itertools
+from types import SimpleNamespace
 
 import numpy as np
 import pandas as pd
@@ -22,6 +23,19 @@ class CustomParallelBackend:
     def map(self, func, *iterables):
         results = [func(*args) for args in zip(*iterables)]
         return results
+
+
+def make_cross_validation_model():
+    return SimpleNamespace(
+        history=pd.DataFrame(
+            {
+                "ds": pd.date_range("2020-01-01", periods=10, freq="D"),
+                "y": np.arange(10, dtype=float),
+            }
+        ),
+        seasonalities={},
+        uncertainty_samples=0,
+    )
 
 
 PARALLEL_METHODS = [None, "processes", "threads", CustomParallelBackend()]
@@ -83,6 +97,93 @@ class TestCrossValidation:
         assert len(np.unique(df_cv["cutoff"])) == 1
         with pytest.raises(ValueError):
             diagnostics.cross_validation(m, horizon="10 days", period="10 days", initial="140 days")
+
+    @pytest.mark.parametrize("raises", [False, True])
+    @pytest.mark.parametrize(
+        ("parallel_method", "executor_name"),
+        [("threads", "ThreadPoolExecutor"), ("processes", "ProcessPoolExecutor")],
+    )
+    def test_cross_validation_internal_executor_lifecycle(
+        self, monkeypatch, parallel_method, executor_name, raises
+    ):
+        m = make_cross_validation_model()
+        cutoff = m.history["ds"].iloc[3]
+        created = []
+
+        class TrackingExecutor:
+            def __init__(self, *args, **kwargs):
+                self.shutdown_calls = 0
+                created.append(self)
+
+            def map(self, func, *iterables):
+                if raises:
+                    raise RuntimeError("map failed")
+                return [func(*args) for args in zip(*iterables)]
+
+            def shutdown(self, wait=True):
+                self.shutdown_calls += 1
+
+        monkeypatch.setattr(
+            diagnostics.concurrent.futures, executor_name, TrackingExecutor
+        )
+        prediction = pd.DataFrame(
+            {"ds": [cutoff], "yhat": [0.0], "y": [0.0], "cutoff": [cutoff]}
+        )
+        monkeypatch.setattr(
+            diagnostics, "single_cutoff_forecast", lambda *args: prediction.copy()
+        )
+
+        if raises:
+            with pytest.raises(RuntimeError, match="map failed"):
+                diagnostics.cross_validation(
+                    m,
+                    horizon="1 day",
+                    cutoffs=[cutoff],
+                    parallel=parallel_method,
+                    disable_tqdm=True,
+                )
+        else:
+            for _ in range(3):
+                result = diagnostics.cross_validation(
+                    m,
+                    horizon="1 day",
+                    cutoffs=[cutoff],
+                    parallel=parallel_method,
+                    disable_tqdm=True,
+                )
+                assert result.loc[0, "yhat"] == 0.0
+
+        expected_calls = 1 if raises else 3
+        assert len(created) == expected_calls
+        assert [executor.shutdown_calls for executor in created] == [1] * expected_calls
+
+    def test_cross_validation_does_not_shutdown_caller_executor(self):
+        m = make_cross_validation_model()
+        cutoff = m.history["ds"].iloc[3]
+        prediction = pd.DataFrame(
+            {"ds": [cutoff], "yhat": [0.0], "y": [0.0], "cutoff": [cutoff]}
+        )
+
+        class CallerExecutor:
+            shutdown_calls = 0
+
+            def map(self, func, *iterables):
+                return [prediction]
+
+            def shutdown(self, wait=True):
+                self.shutdown_calls += 1
+
+        executor = CallerExecutor()
+        result = diagnostics.cross_validation(
+            m,
+            horizon="1 day",
+            cutoffs=[cutoff],
+            parallel=executor,
+            disable_tqdm=True,
+        )
+
+        assert result.loc[0, "yhat"] == 0.0
+        assert executor.shutdown_calls == 0
 
     def test_bad_parallel_methods(self, ts_short, backend):
         m = Prophet(stan_backend=backend)

--- a/python/prophet/tests/test_diagnostics.py
+++ b/python/prophet/tests/test_diagnostics.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import datetime
+import concurrent.futures
 import itertools
 from types import SimpleNamespace
 
@@ -110,18 +111,23 @@ class TestCrossValidation:
         cutoff = m.history["ds"].iloc[3]
         created = []
 
-        class TrackingExecutor:
+        executor_type = concurrent.futures.ThreadPoolExecutor
+
+        class TrackingExecutor(executor_type):
             def __init__(self, *args, **kwargs):
+                kwargs.pop("mp_context", None)
+                super().__init__(*args, **kwargs)
                 self.shutdown_calls = 0
                 created.append(self)
 
             def map(self, func, *iterables):
                 if raises:
                     raise RuntimeError("map failed")
-                return [func(*args) for args in zip(*iterables)]
+                return super().map(func, *iterables)
 
-            def shutdown(self, wait=True):
+            def shutdown(self, wait=True, *, cancel_futures=False):
                 self.shutdown_calls += 1
+                super().shutdown(wait=wait, cancel_futures=cancel_futures)
 
         monkeypatch.setattr(
             diagnostics.concurrent.futures, executor_name, TrackingExecutor
@@ -157,33 +163,27 @@ class TestCrossValidation:
         assert len(created) == expected_calls
         assert [executor.shutdown_calls for executor in created] == [1] * expected_calls
 
-    def test_cross_validation_does_not_shutdown_caller_executor(self):
+    def test_cross_validation_does_not_shutdown_caller_executor(self, monkeypatch):
         m = make_cross_validation_model()
         cutoff = m.history["ds"].iloc[3]
         prediction = pd.DataFrame(
             {"ds": [cutoff], "yhat": [0.0], "y": [0.0], "cutoff": [cutoff]}
         )
 
-        class CallerExecutor:
-            shutdown_calls = 0
-
-            def map(self, func, *iterables):
-                return [prediction]
-
-            def shutdown(self, wait=True):
-                self.shutdown_calls += 1
-
-        executor = CallerExecutor()
-        result = diagnostics.cross_validation(
-            m,
-            horizon="1 day",
-            cutoffs=[cutoff],
-            parallel=executor,
-            disable_tqdm=True,
+        monkeypatch.setattr(
+            diagnostics, "single_cutoff_forecast", lambda *args: prediction.copy()
         )
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            result = diagnostics.cross_validation(
+                m,
+                horizon="1 day",
+                cutoffs=[cutoff],
+                parallel=executor,
+                disable_tqdm=True,
+            )
 
-        assert result.loc[0, "yhat"] == 0.0
-        assert executor.shutdown_calls == 0
+            assert result.loc[0, "yhat"] == 0.0
+            assert executor.submit(lambda: "still usable").result() == "still usable"
 
     def test_bad_parallel_methods(self, ts_short, backend):
         m = Prophet(stan_backend=backend)


### PR DESCRIPTION
Fixes #2355.

This applies the executor cleanup proposed in #2738 and adds focused regression coverage.

## What changed

- Shut down internally created thread and process executors after cross-validation, including error paths.
- Preserve caller-owned executors and Dask clients.
- Cover repeated runs, mapping failures, and caller-owned executors.

## Verification

- Focused diagnostics tests: 5 passed
- Python compile check
- `git diff --check`
- Pyrefly 0.50.0: 0 errors (18 existing suppressions), all 9 configured modules checked. The local hidden-directory exclusion heuristic was disabled; project includes/excludes were unchanged.
