### PR TITLE
fix: avoid deprecated class-scoped fixture instance method

### DIFF
--- a/python/prophet/tests/test_diagnostics.py
+++ b/python/prophet/tests/test_diagnostics.py
@@ -489,7 +489,8 @@ class TestPerformanceMetrics:
 
 class TestProphetCopy:
     @pytest.fixture(scope="class")
-    def data(self, daily_univariate_ts):
+    @staticmethod
+    def data(daily_univariate_ts):
         df = daily_univariate_ts.copy()
         df["cap"] = 200.0
         df["binary_feature"] = [0] * 255 + [1] * 255


### PR DESCRIPTION
Make TestProphetCopy.data a static method because it does not use instance state. This removes the class-scoped instance-method fixture warning introduced in pytest 9.1 and avoids the planned pytest 10 incompatibility without changing fixture scope or data.

Validated on Windows with Python 3.14.5 and pytest 9.1.1 against this checkout's Python source, using the unchanged Stan model's compiled runtime from the Prophet 1.4.0 wheel:
- Before: diagnostics suite — 27 passed, 1 PytestRemovedIn10Warning.
- After: `python -m pytest prophet/tests/test_diagnostics.py -q -W error::pytest.PytestRemovedIn10Warning` — 27 passed, no warnings.

A fresh source build and the full test suite were not run locally.
